### PR TITLE
Add integration test infrastructre

### DIFF
--- a/.github/workflows/aind-behavior-vr-foraging-nwb.yml
+++ b/.github/workflows/aind-behavior-vr-foraging-nwb.yml
@@ -9,6 +9,7 @@ on:
       - release*
   release:
     types: [ published ]
+  workflow_dispatch:
 
 jobs:
   # ╔──────────────────────────╗
@@ -55,6 +56,45 @@ jobs:
       - name: Build
         run: uv build
 
+  # ╔─────────────────────────────────────────────────╗
+  # │   ___       _                        _   _              │
+  # │  |_ _|_ __ | |_ ___  __ _ _ __ __ _| |_(_) ___  _ __  │
+  # │   | || '_ \| __/ _ \/ _` | '__/ _` | __| |/ _ \| '_ \ │
+  # │   | || | | | ||  __/ (_| | | | (_| | |_| | (_) | | | |│
+  # │  |___|_| |_|\__\___|\__, |_|  \__,_|\__|_|\___/|_| |_| │
+  # │                     |___/                               │
+  # ╚─────────────────────────────────────────────────────────╝
+
+  integration-tests:
+    name: Integration tests (S3 datasets)
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-integration')) ||
+      (github.event_name == 'release' && github.event.action == 'published')
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install python dependencies
+        run: uv sync
+
+      - name: Restore integration data cache
+        uses: actions/cache@v4
+        with:
+          path: tests/integration/.cache
+          key: integration-data-${{ hashFiles('tests/integration/datasets.yml') }}
+          restore-keys: |
+            integration-data-
+
+      - name: Run integration tests
+        run: uv run pytest -m integration --tb=short
+
   # ╔─────────────────────────────────────────────────────────────────╗
   # │   ____        _     _ _        ____      _                      │
   # │  |  _ \ _   _| |__ | (_) ___  |  _ \ ___| | ___  __ _ ___  ___  │
@@ -67,7 +107,7 @@ jobs:
   prepare-release:
     runs-on: ubuntu-latest
     name: Set version from release tag
-    needs: tests
+    needs: [tests, integration-tests]
     if: github.event_name == 'release' && github.event.action == 'published'
     outputs:
       version: ${{ steps.get_version.outputs.version }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,32 @@ We use [ruff](https://docs.astral.sh/ruff/) as our primary linting tool.
 Attempt to add tests when new features are added.
 To run the currently available tests, run `uv run pytest` from the root of the repository.
 
+## Integration tests
+
+Integration tests run the parser end-to-end against real datasets stored in a public S3 bucket. They are gated by a pytest marker so they don't run by default.
+
+**Run locally:**
+
+```bash
+uv run pytest -m integration
+```
+
+The first run downloads datasets (~100 MB per dataset) to `tests/integration/.cache/`. Subsequent runs reuse the cache when the S3 ETag matches. The cache directory is gitignored.
+
+**Trigger on a PR:**
+
+Integration tests do not run on every PR. To run them for a specific PR, add the `run-integration` label via the GitHub UI (open the PR, click **Labels** in the right-hand sidebar, and select `run-integration`) or with:
+
+```bash
+gh pr edit <PR_NUMBER> --add-label run-integration
+```
+
+The integration job runs automatically on push to `main` and on `release: published`. A release cannot ship without the integration suite passing.
+
+**Adding a dataset:**
+
+Add an entry to `tests/integration/datasets.yml`. The manifest schema and full field documentation are in `tests/integration/model.py` (Pydantic model). The `rationale` field is required and is printed alongside any test failure to make triage fast.
+
 ### Lock files
 
 We use [uv](https://docs.astral.sh/uv/) to manage our lock files and therefore encourage everyone to use uv as a package manager as well.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ ignore-words-list = 'nd'
 
 [tool.pytest.ini_options]
 addopts = "--strict-markers --tb=short --cov=src --cov-report=term-missing --cov-fail-under=0"
+markers = [
+  "integration: integration tests that download data from S3 (run with `-m integration`)",
+]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,2 +1,1 @@
 .cache/
-*.etag

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,2 @@
+.cache/
+*.etag

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -4,6 +4,10 @@ pytest_configure patches NwbSession to use local JSON files instead of the
 AIND metadata API, so integration tests work without network access to DocDB.
 """
 
+import json
+import logging
+import os
+import time
 from pathlib import Path, PurePosixPath
 from urllib.parse import urlparse
 
@@ -15,32 +19,27 @@ from botocore.config import Config
 
 from .model import DatasetEntry, DatasetManifest, load_manifest
 
-# ---------------------------------------------------------------------------
-# Module-level constants
-# ---------------------------------------------------------------------------
+_log = logging.getLogger(__name__)
 
 MANIFEST_PATH = Path(__file__).parent / "datasets.yml"
 CACHE_ROOT = Path(__file__).parent / ".cache"
 
-# Glob patterns excluded from every download regardless of the per-entry
-# `exclude` list. Video files are large, slow to download, and never used
-# by the parser — opt back in only if a future test needs them.
+# Single per-cache JSON index of S3 ETags, keyed by "<bucket>/<key>". Lives at
+# the cache root rather than next to each cached file so that nothing inside
+# any dataset's local prefix can be mistaken for data by glob-based parsers.
+ETAG_INDEX_PATH = CACHE_ROOT / "_etags.json"
+
+# Video files are large, slow to download, and never used by the parser —
+# opt back in only if a future test needs them.
 DEFAULT_EXCLUDES: tuple[str, ...] = ("**/*.mp4", "**/*.avi", "**/*.mkv")
 
-# Load manifest at collection time so schema errors surface immediately.
 _manifest: DatasetManifest = load_manifest(MANIFEST_PATH)
 
 
-# ---------------------------------------------------------------------------
-# Patch NwbSession to skip DocDB and use local JSON files instead
-# ---------------------------------------------------------------------------
-
-
 def pytest_configure(config: pytest.Config) -> None:
-    """Swap NwbSession._get_aind_data_schema_json to the local-path variant.
+    """Swap NwbSession._get_aind_data_schema_json to read local JSON files.
 
-    This runs when conftest.py is loaded (i.e. only for the integration/
-    directory), so it does not affect the unit-test suite.
+    Scoped to the integration/ directory; does not affect the unit-test suite.
     """
     from aind_behavior_vr_foraging_nwb.nwb_file import NwbSession, _AindDataSchemaJson
 
@@ -50,20 +49,10 @@ def pytest_configure(config: pytest.Config) -> None:
     setattr(NwbSession, "_get_aind_data_schema_json", _from_root)
 
 
-# ---------------------------------------------------------------------------
-# Fixtures
-# ---------------------------------------------------------------------------
-
-
 @pytest.fixture(scope="session")
 def s3_client() -> BaseClient:
     """Anonymous S3 client for accessing public buckets."""
     return boto3.client("s3", config=Config(signature_version=UNSIGNED))
-
-
-# ---------------------------------------------------------------------------
-# Download helpers
-# ---------------------------------------------------------------------------
 
 
 def _is_excluded(rel_key: str, patterns: list[str]) -> bool:
@@ -72,29 +61,53 @@ def _is_excluded(rel_key: str, patterns: list[str]) -> bool:
     return any(PurePosixPath(lowered).match(p.lower()) for p in patterns)
 
 
-def _needs_download(cached_path: Path, remote_etag: str) -> bool:
-    """Return True when the cached file is absent or stale."""
-    etag_path = cached_path.with_suffix(cached_path.suffix + ".etag")
-    if not cached_path.exists() or not etag_path.exists():
-        return True
-    return etag_path.read_text().strip() != remote_etag.strip('"')
+def _format_bytes(n: int) -> str:
+    """Human-readable byte count for log lines."""
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB"):
+        if size < 1024:
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size:.1f} TB"
 
 
-def _fetch(s3: BaseClient, bucket: str, key: str, cache_root: Path) -> Path:
-    """Download *key* from *bucket* to the local cache, skipping if ETag matches."""
+def _load_etag_index(path: Path) -> dict[str, str]:
+    """Read the cache-wide ETag index, or return {} if absent."""
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text())
+
+
+def _save_etag_index(path: Path, index: dict[str, str]) -> None:
+    """Atomically persist the ETag index via temp-file + os.replace."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(index, indent=2, sort_keys=True))
+    os.replace(tmp, path)
+
+
+def _fetch(s3: BaseClient, bucket: str, key: str, cache_root: Path, etag_index: dict[str, str]) -> bool:
+    """Download *key* from *bucket* to the local cache, skipping if ETag matches.
+
+    *etag_index* is mutated in place when a download occurs and persisted
+    after each successful fetch so a partial run leaves a recoverable state.
+
+    Returns True when a network download was performed, False on a cache hit.
+    """
     head = s3.head_object(Bucket=bucket, Key=key)
-    remote_etag: str = head["ETag"]
+    remote_etag: str = head["ETag"].strip('"')
+    cache_key = f"{bucket}/{key}"
 
     cached_path = cache_root / bucket / key
     cached_path.parent.mkdir(parents=True, exist_ok=True)
 
-    if not _needs_download(cached_path, remote_etag):
-        return cached_path  # cache hit
+    if cached_path.exists() and etag_index.get(cache_key) == remote_etag:
+        return False
 
     s3.download_file(bucket, key, str(cached_path))
-    etag_path = cached_path.with_suffix(cached_path.suffix + ".etag")
-    etag_path.write_text(remote_etag)
-    return cached_path
+    etag_index[cache_key] = remote_etag
+    _save_etag_index(ETAG_INDEX_PATH, etag_index)
+    return True
 
 
 def download_dataset(s3: BaseClient, entry: DatasetEntry, cache_root: Path) -> Path:
@@ -120,19 +133,42 @@ def download_dataset(s3: BaseClient, entry: DatasetEntry, cache_root: Path) -> P
     prefix: str = parsed.path.lstrip("/")
 
     effective_excludes = list(entry.exclude) + list(DEFAULT_EXCLUDES)
+    etag_index = _load_etag_index(ETAG_INDEX_PATH)
 
     paginator = s3.get_paginator("list_objects_v2")
-    pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
-
-    for page in pages:
+    keys: list[str] = []
+    total_bytes = 0
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
         for obj in page.get("Contents", []):
             key: str = obj["Key"]
             rel_key = key[len(prefix) :]
             if not rel_key:
-                # Skip the prefix "directory" object itself if it exists
                 continue
             if _is_excluded(rel_key, effective_excludes):
                 continue
-            _fetch(s3, bucket, key, cache_root)
+            keys.append(key)
+            total_bytes += int(obj.get("Size", 0))
+
+    _log.info(
+        "Downloading dataset %s — %d objects, %s",
+        entry.id,
+        len(keys),
+        _format_bytes(total_bytes),
+    )
+    start = time.monotonic()
+
+    fetched = 0
+    for key in keys:
+        if _fetch(s3, bucket, key, cache_root, etag_index):
+            fetched += 1
+
+    elapsed = time.monotonic() - start
+    _log.info(
+        "Dataset %s ready in %.1fs (%d fetched, %d cache hits)",
+        entry.id,
+        elapsed,
+        fetched,
+        len(keys) - fetched,
+    )
 
     return cache_root / bucket / prefix.rstrip("/")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,138 @@
+"""Integration test fixtures and helpers.
+
+pytest_configure patches NwbSession to use local JSON files instead of the
+AIND metadata API, so integration tests work without network access to DocDB.
+"""
+
+from pathlib import Path, PurePosixPath
+from urllib.parse import urlparse
+
+import boto3
+import pytest
+from botocore import UNSIGNED
+from botocore.client import BaseClient
+from botocore.config import Config
+
+from .model import DatasetEntry, DatasetManifest, load_manifest
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+MANIFEST_PATH = Path(__file__).parent / "datasets.yml"
+CACHE_ROOT = Path(__file__).parent / ".cache"
+
+# Glob patterns excluded from every download regardless of the per-entry
+# `exclude` list. Video files are large, slow to download, and never used
+# by the parser — opt back in only if a future test needs them.
+DEFAULT_EXCLUDES: tuple[str, ...] = ("**/*.mp4", "**/*.avi", "**/*.mkv")
+
+# Load manifest at collection time so schema errors surface immediately.
+_manifest: DatasetManifest = load_manifest(MANIFEST_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Patch NwbSession to skip DocDB and use local JSON files instead
+# ---------------------------------------------------------------------------
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Swap NwbSession._get_aind_data_schema_json to the local-path variant.
+
+    This runs when conftest.py is loaded (i.e. only for the integration/
+    directory), so it does not affect the unit-test suite.
+    """
+    from aind_behavior_vr_foraging_nwb.nwb_file import NwbSession, _AindDataSchemaJson
+
+    def _from_root(self: NwbSession) -> _AindDataSchemaJson:
+        return _AindDataSchemaJson.from_root_path(self.root_path)
+
+    setattr(NwbSession, "_get_aind_data_schema_json", _from_root)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def s3_client() -> BaseClient:
+    """Anonymous S3 client for accessing public buckets."""
+    return boto3.client("s3", config=Config(signature_version=UNSIGNED))
+
+
+# ---------------------------------------------------------------------------
+# Download helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_excluded(rel_key: str, patterns: list[str]) -> bool:
+    """Return True if *rel_key* matches any exclude pattern (case-insensitive)."""
+    lowered = rel_key.lower()
+    return any(PurePosixPath(lowered).match(p.lower()) for p in patterns)
+
+
+def _needs_download(cached_path: Path, remote_etag: str) -> bool:
+    """Return True when the cached file is absent or stale."""
+    etag_path = cached_path.with_suffix(cached_path.suffix + ".etag")
+    if not cached_path.exists() or not etag_path.exists():
+        return True
+    return etag_path.read_text().strip() != remote_etag.strip('"')
+
+
+def _fetch(s3: BaseClient, bucket: str, key: str, cache_root: Path) -> Path:
+    """Download *key* from *bucket* to the local cache, skipping if ETag matches."""
+    head = s3.head_object(Bucket=bucket, Key=key)
+    remote_etag: str = head["ETag"]
+
+    cached_path = cache_root / bucket / key
+    cached_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if not _needs_download(cached_path, remote_etag):
+        return cached_path  # cache hit
+
+    s3.download_file(bucket, key, str(cached_path))
+    etag_path = cached_path.with_suffix(cached_path.suffix + ".etag")
+    etag_path.write_text(remote_etag)
+    return cached_path
+
+
+def download_dataset(s3: BaseClient, entry: DatasetEntry, cache_root: Path) -> Path:
+    """Download all non-excluded objects for *entry* and return the local root path.
+
+    Parameters
+    ----------
+    s3:
+        An authenticated (or anonymous) boto3 S3 client.
+    entry:
+        Manifest entry describing the dataset.
+    cache_root:
+        Parent directory for the local cache tree.
+
+    Returns
+    -------
+    Path
+        Local directory equivalent to the S3 prefix — suitable for passing
+        directly to ``NwbSession(...)``.
+    """
+    parsed = urlparse(entry.uri)
+    bucket: str = parsed.netloc
+    prefix: str = parsed.path.lstrip("/")
+
+    effective_excludes = list(entry.exclude) + list(DEFAULT_EXCLUDES)
+
+    paginator = s3.get_paginator("list_objects_v2")
+    pages = paginator.paginate(Bucket=bucket, Prefix=prefix)
+
+    for page in pages:
+        for obj in page.get("Contents", []):
+            key: str = obj["Key"]
+            rel_key = key[len(prefix) :]
+            if not rel_key:
+                # Skip the prefix "directory" object itself if it exists
+                continue
+            if _is_excluded(rel_key, effective_excludes):
+                continue
+            _fetch(s3, bucket, key, cache_root)
+
+    return cache_root / bucket / prefix.rstrip("/")

--- a/tests/integration/datasets.yml
+++ b/tests/integration/datasets.yml
@@ -1,0 +1,23 @@
+# Integration test datasets. See docs/plans/2026-05-09-integration-tests-design.md.
+#
+# Default exclusions (always applied, in addition to per-entry `exclude`):
+#   **/*.mp4, **/*.avi, **/*.mkv
+# See DEFAULT_EXCLUDES in tests/integration/conftest.py.
+#
+# Schema (every field):
+# datasets:
+#   - id: <stable-handle>            # unique kebab-case identifier
+#     uri: s3://bucket/prefix/       # must end with '/'
+#     rationale: |                   # required; explains why this dataset is here
+#       Multi-line description of why this dataset is in the suite.
+#     exclude:                       # optional; pathlib glob, case-insensitive
+#       - "videos/**"
+#       - "**/*.avi"
+#     expected:                      # optional; assertion invariants
+#       n_trials: 412
+#       n_blocks: 4
+#       n_patches: 16
+#       nwb_validates: true
+#     xfail: false                   # optional; default false
+#     xfail_reason: ""               # optional; only when xfail: true
+datasets: []

--- a/tests/integration/model.py
+++ b/tests/integration/model.py
@@ -1,0 +1,80 @@
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ExpectedInvariants(BaseModel):
+    """Lightweight scalar invariants asserted against the parsed dataset.
+
+    All fields are optional; only the present ones are checked. Unknown
+    fields are rejected at validation time so typos in the YAML manifest
+    surface immediately rather than silently being skipped.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    n_trials: Optional[int] = Field(
+        default=None,
+        description="Expected total number of trials in the parsed session. Asserted against the trial table row count.",
+    )
+    n_blocks: Optional[int] = Field(
+        default=None,
+        description="Expected number of blocks in the session.",
+    )
+    n_patches: Optional[int] = Field(
+        default=None,
+        description="Expected number of patches in the session.",
+    )
+    nwb_validates: Optional[bool] = Field(
+        default=None,
+        description="If true, the generated NWB file must pass pynwb validation. If false or omitted, validation is skipped.",
+    )
+
+
+class DatasetEntry(BaseModel):
+    """A single integration-test dataset entry in the manifest."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(
+        description="Stable short handle used as the pytest test ID. Must be unique within the manifest. Avoid spaces; kebab-case recommended.",
+    )
+    uri: str = Field(
+        description="Full s3:// URI of the dataset prefix (a 'folder' in S3). Must end with a trailing slash. Listed and downloaded recursively, subject to `exclude`.",
+    )
+    rationale: str = Field(
+        description="Free-form note explaining why this dataset is in the suite — what it tests, what bug it caught, what edge case it represents. Printed alongside any failure to make triage fast.",
+    )
+    exclude: List[str] = Field(
+        default_factory=list,
+        description="Glob patterns (pathlib.PurePosixPath.match semantics, case-insensitive) matched against each S3 key relative to the dataset prefix. Any match excludes the object from download. Examples: 'videos/**', '**/*.avi', 'raw/calibration_*.bin'.",
+    )
+    expected: Optional[ExpectedInvariants] = Field(
+        default=None,
+        description="Optional scalar invariants to assert after parsing. If omitted, the dataset only gets the smoke test (parser must not crash).",
+    )
+    xfail: bool = Field(
+        default=False,
+        description="If true, the test is marked pytest.xfail(strict=True) — failure is expected, unexpected pass becomes a hard failure forcing removal of the marker. Use to keep known-broken datasets in the suite without blocking CI.",
+    )
+    xfail_reason: str = Field(
+        default="",
+        description="Human-readable explanation displayed alongside the xfail marker. Only meaningful when `xfail` is true.",
+    )
+
+
+class DatasetManifest(BaseModel):
+    """Top-level manifest describing every integration-test dataset."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    datasets: List[DatasetEntry] = Field(
+        description="Ordered list of dataset entries. Order has no semantic meaning beyond display.",
+    )
+
+
+def load_manifest(path: Path) -> DatasetManifest:
+    """Parse and validate the YAML manifest at `path`. Raises pydantic.ValidationError on schema problems."""
+    return DatasetManifest.model_validate(yaml.safe_load(path.read_text()))

--- a/tests/integration/test_datasets.py
+++ b/tests/integration/test_datasets.py
@@ -1,0 +1,94 @@
+"""Parametrized integration tests — one test per entry in datasets.yml.
+
+Run with::
+
+    uv run pytest -m integration
+
+The suite is gated behind the ``integration`` marker so the default
+``uv run pytest`` invocation is unaffected.
+"""
+
+import pytest
+
+from .conftest import CACHE_ROOT, _manifest, download_dataset
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Parametrize over manifest entries
+# ---------------------------------------------------------------------------
+
+_entries = _manifest.datasets
+_ids = [e.id for e in _entries]
+
+
+# ---------------------------------------------------------------------------
+# Invariant assertion helper
+# ---------------------------------------------------------------------------
+
+
+def _assert_invariants(session, nwb, entry) -> None:  # type: ignore[no-untyped-def]
+    """Dispatch per-field invariant checks from *entry.expected*."""
+    from aind_behavior_vr_foraging_nwb.processing import TrialTableProcessor
+
+    inv = entry.expected
+
+    # We need the trial table for n_trials, n_blocks, and n_patches.
+    # process_to_sites() returns the full list without modifying the NWB file.
+    processor = TrialTableProcessor(session.dataset)
+
+    if inv.n_trials is not None or inv.n_blocks is not None or inv.n_patches is not None:
+        sites = processor.process_to_sites()
+
+        if inv.n_trials is not None:
+            actual = len(sites)
+            assert actual == inv.n_trials, (
+                f"{entry.id}: expected n_trials={inv.n_trials}, got {actual}\nRationale: {entry.rationale}"
+            )
+
+        if inv.n_blocks is not None:
+            actual = len({s.block_index for s in sites})
+            assert actual == inv.n_blocks, (
+                f"{entry.id}: expected n_blocks={inv.n_blocks}, got {actual}\nRationale: {entry.rationale}"
+            )
+
+        if inv.n_patches is not None:
+            actual = len({s.patch_index for s in sites})
+            assert actual == inv.n_patches, (
+                f"{entry.id}: expected n_patches={inv.n_patches}, got {actual}\nRationale: {entry.rationale}"
+            )
+
+    if inv.nwb_validates:
+        import pynwb
+
+        errors = pynwb.validate(nwb)
+        assert not errors, f"{entry.id}: pynwb validation failed.\nErrors: {errors}\nRationale: {entry.rationale}"
+
+
+# ---------------------------------------------------------------------------
+# Test function
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("entry", _entries, ids=_ids)
+def test_dataset(entry, s3_client, request) -> None:  # type: ignore[no-untyped-def]
+    """Smoke-test the parser against a real dataset and check declared invariants."""
+    if entry.xfail:
+        request.applymarker(
+            pytest.mark.xfail(
+                strict=True,
+                reason=entry.xfail_reason or "marked xfail in manifest",
+            )
+        )
+
+    try:
+        local_path = download_dataset(s3_client, entry, CACHE_ROOT)
+        from aind_behavior_vr_foraging_nwb.nwb_file import NwbSession
+
+        session = NwbSession(local_path)
+        nwb = session.process()
+    except Exception as e:
+        pytest.fail(f"Dataset {entry.id} failed parser smoke test.\nRationale: {entry.rationale}\nError: {e}")
+
+    if entry.expected is not None:
+        _assert_invariants(session, nwb, entry)


### PR DESCRIPTION
## Summary

Adds an opt-in integration-test suite that exercises the parser end-to-end against real datasets stored in a public S3 bucket. Datasets are declared in a small YAML manifest; tests run smoke checks plus optional scalar invariants (`n_trials`, `n_blocks`, `n_patches`, `nwb_validates`).

## What's in the box

- **`tests/integration/datasets.yml`** — manifest of datasets to test. Each entry carries an `s3://` URI, a required free-form `rationale` explaining why the dataset is in the suite (printed alongside any failure), optional `exclude` glob patterns, optional `expected` invariants, and an `xfail`/`xfail_reason` pair for known-broken sessions. Ships empty (`datasets: []`); add entries as needed. Schema is enforced by a Pydantic model (`tests/integration/model.py`, `extra="forbid"` everywhere).
- **`tests/integration/conftest.py`** — anonymous boto3 client, ETag-keyed local cache at `tests/integration/.cache/` (gitignored). Default excludes `**/*.mp4`, `**/*.avi`, `**/*.mkv`.
- **`tests/integration/test_datasets.py`** — parametrizes one test per manifest entry; gated behind `@pytest.mark.integration` so default `pytest` is unaffected.
- **CI** — new ubuntu-only `integration-tests` job, wired into `prepare-release.needs:` so PyPI publish cannot ship without integration passing.

## How to trigger

**Locally:**
```bash
uv run pytest -m integration
```

**On a PR** — apply the `run-integration` label:
```bash
gh pr edit <PR_NUMBER> --add-label run-integration
```
or click "Labels" in the GitHub UI. Without the label, PRs do not run the integration suite.

**Automatically:**
- push to `main`
- release publication (gates `prepare-release`)
- manual `workflow_dispatch`
