### PR TITLE
Use RELEASE_PAT to bypass branch protection on release push

### DIFF
--- a/.github/workflows/aind-behavior-vr-foraging-packaging.yml
+++ b/.github/workflows/aind-behavior-vr-foraging-packaging.yml
@@ -117,6 +117,9 @@ jobs:
         with:
           fetch-depth: 0
           ref: main
+          # PAT from an admin account so the version-bump commit and tag
+          # push below can bypass the branch ruleset protecting `main`.
+          token: ${{ secrets.RELEASE_PAT }}
 
       - uses: astral-sh/setup-uv@v8.2.0
         with:


### PR DESCRIPTION
## Problem
The `prepare-release` job pushes the version-bump commit and moved release tag directly to `main`. It checked out with the default `GITHUB_TOKEN` (identity `github-actions[bot]`), which is **not** a bypass actor on the `main` branch ruleset, so `git push origin main` was rejected by the `pull_request` rule.

## Fix
Check out with `token: ${{ secrets.RELEASE_PAT }}` in `prepare-release`, so the push authenticates as an admin account that **is** in the ruleset's bypass actors. This mirrors the approach already used in the `Aind.Behavior.VrForaging` repo.

`RELEASE_PAT` is provided as an organization secret scoped to this repo — no ruleset change required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)