### PR TITLE
Fix Sniffing NWB packaging 

### DIFF
--- a/src/aind_behavior_vr_foraging_packaging/processing/_sniffing.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_sniffing.py
@@ -47,10 +47,11 @@ class SniffingProcessor(AbstractProcessor):
                 name="sniffing",
                 data=df["voltage"].values,
                 unit="V",
-                starting_time=float(df.index[0]),
-                rate=fs,
                 timestamps=df.index.values,
-                description="Filtered breathing/sniff signal derived from the sniff detector raw voltage.",
+                description=(
+                    "Filtered breathing/sniff signal derived from the sniff detector raw voltage "
+                    f"at sampling rate {fs} Hz."
+                ),
             )
         )
         return nwb_file

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Fixtures shared across the test suite."""
+
+from datetime import datetime, timezone
+
+import pytest
+from pynwb import NWBFile
+
+
+@pytest.fixture
+def nwb_file() -> NWBFile:
+    """A minimal, empty NWBFile for processors to write into."""
+    return NWBFile(
+        session_description="test",
+        identifier="test",
+        session_start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )

--- a/tests/processing/test_sniffing.py
+++ b/tests/processing/test_sniffing.py
@@ -1,0 +1,106 @@
+"""Tests for SniffingProcessor."""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aind_behavior_vr_foraging_packaging.processing._sniffing import SniffingProcessor
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_processor(timestamps, voltage, sampling_rate_hz=100.0) -> SniffingProcessor:
+    """Processor whose compute() returns a fixed sniff frame, as _compute() would build it."""
+    df = pd.DataFrame(
+        {"voltage": np.asarray(voltage, dtype=float)},
+        index=pd.Index(np.asarray(timestamps, dtype=float), name="timestamp"),
+    )
+    if sampling_rate_hz is not None:
+        df.attrs["sampling_rate_hz"] = sampling_rate_hz
+
+    proc = SniffingProcessor.__new__(SniffingProcessor)
+    proc._dataset = MagicMock()
+    proc._dataset.version = "0.6.0"  # required by AbstractProcessor.compute() for dataset_version
+    proc._raise_on_error = False
+    proc._resampling_frequency_hz = None
+    proc.compute = lambda: df  # bypass the harp stream read; nwbize() only consumes the frame
+    return proc
+
+
+def _empty_nwb():
+    """A minimal real NWBFile — the pynwb TimeSeries validation is the point of these tests."""
+    from datetime import datetime, timezone
+
+    from pynwb import NWBFile
+
+    return NWBFile(
+        session_description="test",
+        identifier="test",
+        session_start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSniffingNwbize:
+    """nwbize() adds a sniffing TimeSeries to the behavior processing module."""
+
+    def test_adds_timeseries_to_behavior_module(self):
+        proc = _make_processor([0.0, 0.01, 0.02], [1.0, 2.0, 3.0])
+        nwb = proc.nwbize(_empty_nwb())
+
+        module = nwb.processing["behavior"]
+        ts = module["sniffing"]
+        assert ts.unit == "V"
+        assert ts.data.tolist() == [1.0, 2.0, 3.0]
+
+    def test_uses_timestamps_not_rate(self):
+        """Regression: passing timestamps together with starting_time/rate raises in pynwb.
+
+        NWB treats the two as mutually exclusive representations, so nwbize() must pick one.
+        """
+        proc = _make_processor([0.5, 0.51, 0.52], [1.0, 2.0, 3.0])
+        ts = proc.nwbize(_empty_nwb()).processing["behavior"]["sniffing"]
+
+        assert ts.timestamps is not None
+        assert list(ts.timestamps) == [0.5, 0.51, 0.52]
+        assert ts.rate is None
+        assert ts.starting_time is None
+
+    def test_description_records_sampling_rate(self):
+        proc = _make_processor([0.0, 0.01], [1.0, 2.0], sampling_rate_hz=250.0)
+        ts = proc.nwbize(_empty_nwb()).processing["behavior"]["sniffing"]
+        assert "250.0 Hz" in ts.description
+
+    def test_reuses_existing_behavior_module(self):
+        """A processor that runs after another must not create a second behavior module."""
+        from pynwb.base import ProcessingModule
+
+        nwb = _empty_nwb()
+        nwb.add_processing_module(ProcessingModule(name="behavior", description="existing"))
+
+        proc = _make_processor([0.0, 0.01], [1.0, 2.0])
+        nwb = proc.nwbize(nwb)
+
+        assert list(nwb.processing.keys()) == ["behavior"]
+        assert nwb.processing["behavior"].description == "existing"
+        assert "sniffing" in nwb.processing["behavior"].data_interfaces
+
+    def test_returns_the_nwb_file(self):
+        proc = _make_processor([0.0, 0.01], [1.0, 2.0])
+        nwb = _empty_nwb()
+        assert proc.nwbize(nwb) is nwb
+
+    @pytest.mark.parametrize("attrs_rate", [None, 0.0])
+    def test_missing_or_zero_sampling_rate_still_writes(self, attrs_rate):
+        """df.attrs may lack sampling_rate_hz; that must not block the TimeSeries."""
+        proc = _make_processor([0.0, 0.01], [1.0, 2.0], sampling_rate_hz=attrs_rate)
+        ts = proc.nwbize(_empty_nwb()).processing["behavior"]["sniffing"]
+        assert list(ts.timestamps) == [0.0, 0.01]

--- a/tests/processing/test_sniffing.py
+++ b/tests/processing/test_sniffing.py
@@ -21,8 +21,8 @@ DURATION_S = 5.0
 
 
 class _InMemoryStream(DataStream):
-    def _reader(self, frame: pd.DataFrame) -> pd.DataFrame:
-        return frame
+    def _reader(self, params: pd.DataFrame) -> pd.DataFrame:
+        return params
 
 
 def _sine_dataset() -> Dataset:

--- a/tests/processing/test_sniffing.py
+++ b/tests/processing/test_sniffing.py
@@ -1,106 +1,58 @@
-"""Tests for SniffingProcessor."""
+"""Tests for ``SniffingProcessor``.
 
-from unittest.mock import MagicMock
+The processor is run end-to-end on a synthetic dataset: a 4 Hz sine wave
+sampled at 200 Hz, wrapped in a real ``contraqctor`` ``Dataset`` whose
+``RawVoltage`` stream is served from memory. Nothing on the processor is
+stubbed, so ``nwbize()`` exercises the real resample/band-pass path and the
+real pynwb ``TimeSeries`` validation.
+"""
+
+import typing as ty
 
 import numpy as np
 import pandas as pd
-import pytest
+from contraqctor.contract import Dataset, DataStream, DataStreamCollection
 
 from aind_behavior_vr_foraging_packaging.processing._sniffing import SniffingProcessor
 
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
+SAMPLING_RATE_HZ = 200.0
+SINE_FREQUENCY_HZ = 4.0  # inside the 0.2-20 Hz breathing band the processor keeps
+DURATION_S = 5.0
 
 
-def _make_processor(timestamps, voltage, sampling_rate_hz=100.0) -> SniffingProcessor:
-    """Processor whose compute() returns a fixed sniff frame, as _compute() would build it."""
-    df = pd.DataFrame(
-        {"voltage": np.asarray(voltage, dtype=float)},
-        index=pd.Index(np.asarray(timestamps, dtype=float), name="timestamp"),
+class _InMemoryStream(DataStream):
+    def _reader(self, frame: pd.DataFrame) -> pd.DataFrame:
+        return frame
+
+
+def _sine_dataset() -> Dataset:
+    """Dataset exposing ``Behavior::HarpSniffDetector::RawVoltage`` as a sine wave."""
+    timestamps = np.arange(0.0, DURATION_S, 1.0 / SAMPLING_RATE_HZ)
+    raw_voltage = pd.DataFrame(
+        {"RawVoltage": np.sin(2 * np.pi * SINE_FREQUENCY_HZ * timestamps), "MessageType": "EVENT"},
+        index=pd.Index(timestamps, name="timestamp"),
     )
-    if sampling_rate_hz is not None:
-        df.attrs["sampling_rate_hz"] = sampling_rate_hz
-
-    proc = SniffingProcessor.__new__(SniffingProcessor)
-    proc._dataset = MagicMock()
-    proc._dataset.version = "0.6.0"  # required by AbstractProcessor.compute() for dataset_version
-    proc._raise_on_error = False
-    proc._resampling_frequency_hz = None
-    proc.compute = lambda: df  # bypass the harp stream read; nwbize() only consumes the frame
-    return proc
-
-
-def _empty_nwb():
-    """A minimal real NWBFile — the pynwb TimeSeries validation is the point of these tests."""
-    from datetime import datetime, timezone
-
-    from pynwb import NWBFile
-
-    return NWBFile(
-        session_description="test",
-        identifier="test",
-        session_start_time=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    sniff_detector = DataStreamCollection(
+        "HarpSniffDetector", [_InMemoryStream("RawVoltage", reader_params=raw_voltage)]
     )
+    behavior = DataStreamCollection("Behavior", [sniff_detector])
+    return Dataset("SyntheticSniffDataset", version="0.6.0", data_streams=[behavior])
 
 
-# ---------------------------------------------------------------------------
-# Tests
-# ---------------------------------------------------------------------------
+def test_nwbize(nwb_file: ty.Any) -> None:
+    """The sniff signal lands in the behavior module as a timestamped TimeSeries."""
+    processor = SniffingProcessor(_sine_dataset(), resampling_frequency_hz=SAMPLING_RATE_HZ)
 
+    result = processor.nwbize(nwb_file)
 
-class TestSniffingNwbize:
-    """nwbize() adds a sniffing TimeSeries to the behavior processing module."""
-
-    def test_adds_timeseries_to_behavior_module(self):
-        proc = _make_processor([0.0, 0.01, 0.02], [1.0, 2.0, 3.0])
-        nwb = proc.nwbize(_empty_nwb())
-
-        module = nwb.processing["behavior"]
-        ts = module["sniffing"]
-        assert ts.unit == "V"
-        assert ts.data.tolist() == [1.0, 2.0, 3.0]
-
-    def test_uses_timestamps_not_rate(self):
-        """Regression: passing timestamps together with starting_time/rate raises in pynwb.
-
-        NWB treats the two as mutually exclusive representations, so nwbize() must pick one.
-        """
-        proc = _make_processor([0.5, 0.51, 0.52], [1.0, 2.0, 3.0])
-        ts = proc.nwbize(_empty_nwb()).processing["behavior"]["sniffing"]
-
-        assert ts.timestamps is not None
-        assert list(ts.timestamps) == [0.5, 0.51, 0.52]
-        assert ts.rate is None
-        assert ts.starting_time is None
-
-    def test_description_records_sampling_rate(self):
-        proc = _make_processor([0.0, 0.01], [1.0, 2.0], sampling_rate_hz=250.0)
-        ts = proc.nwbize(_empty_nwb()).processing["behavior"]["sniffing"]
-        assert "250.0 Hz" in ts.description
-
-    def test_reuses_existing_behavior_module(self):
-        """A processor that runs after another must not create a second behavior module."""
-        from pynwb.base import ProcessingModule
-
-        nwb = _empty_nwb()
-        nwb.add_processing_module(ProcessingModule(name="behavior", description="existing"))
-
-        proc = _make_processor([0.0, 0.01], [1.0, 2.0])
-        nwb = proc.nwbize(nwb)
-
-        assert list(nwb.processing.keys()) == ["behavior"]
-        assert nwb.processing["behavior"].description == "existing"
-        assert "sniffing" in nwb.processing["behavior"].data_interfaces
-
-    def test_returns_the_nwb_file(self):
-        proc = _make_processor([0.0, 0.01], [1.0, 2.0])
-        nwb = _empty_nwb()
-        assert proc.nwbize(nwb) is nwb
-
-    @pytest.mark.parametrize("attrs_rate", [None, 0.0])
-    def test_missing_or_zero_sampling_rate_still_writes(self, attrs_rate):
-        """df.attrs may lack sampling_rate_hz; that must not block the TimeSeries."""
-        proc = _make_processor([0.0, 0.01], [1.0, 2.0], sampling_rate_hz=attrs_rate)
-        ts = proc.nwbize(_empty_nwb()).processing["behavior"]["sniffing"]
-        assert list(ts.timestamps) == [0.0, 0.01]
+    assert result is nwb_file
+    time_series = result.processing["behavior"]["sniffing"]
+    assert time_series.unit == "V"
+    assert f"{SAMPLING_RATE_HZ} Hz" in time_series.description
+    # NWB treats timestamps and starting_time/rate as mutually exclusive; passing
+    # both raises in pynwb, so nwbize() must commit to timestamps alone.
+    assert time_series.rate is None
+    assert time_series.starting_time is None
+    assert len(time_series.timestamps) == len(time_series.data)
+    # the band-pass keeps the 4 Hz sine, so the signal is not flattened away
+    assert np.ptp(time_series.data) > 0.1


### PR DESCRIPTION
Attempts to close #41. Went with using timestamps since that was how some of the other processing modules had it. Should be easy to modify if we want to use start_time/rate. Put the `fs` as part of the description for now due to this limitation of NWB