### PR TITLE
Gracefully handle manual rewards for legacy datasets

### DIFF
--- a/src/aind_behavior_vr_foraging_packaging/processing/_legacy_site_table.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_legacy_site_table.py
@@ -177,8 +177,9 @@ class LegacySiteTableProcessor(SiteTableProcessor):
         """
         if len(candidates) <= 1:
             return candidates
-        after = candidates if np.isnan(choice_time) else candidates[candidates.index >= choice_time]
-        chosen = (after if not after.empty else candidates).iloc[:1]
+        after_tone = np.flatnonzero(np.asarray(candidates.index >= choice_time))
+        pos = int(after_tone[0]) if after_tone.size else 0
+        chosen = candidates.iloc[pos : pos + 1]
         logger.warning(
             "%d %s events in one site interval; keeping the one at t=%s (first at/after the "
             "choice tone). The other %d are assumed to be manually delivered — manual and earned "

--- a/src/aind_behavior_vr_foraging_packaging/processing/_legacy_site_table.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_legacy_site_table.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 
 _LEGACY_OLFACTOMETER_CHANNEL_COUNT = 3
 
+_TRewardEvents = t.TypeVar("_TRewardEvents", pd.DataFrame, pd.Series)
+
 
 class LegacySiteTableProcessor(SiteTableProcessor):
     """SiteTableProcessor for VR foraging datasets with schema version < 0.6.0.
@@ -25,6 +27,10 @@ class LegacySiteTableProcessor(SiteTableProcessor):
     - Choice cue is read from HarpBehavior.PwmStart with dynamic port detection
       (PwmDO1 in v0.3, PwmDO2 in v0.4+; port is inferred from which channel is active).
     - PatchStateAtReward is reconstructed from split PatchReward*.json files when absent.
+    - A site interval may contain several water deliveries, because manual (experimenter)
+      water was not logged separately until 0.6.0 added ``ForceGiveReward``. The first
+      delivery at or after the choice tone is taken as the earned one; see
+      :meth:`_first_after_choice`.
     - HarpTreadmill is optional; friction defaults to 0 when absent.
     - IsStopped and velocity streams are absent; last_stop_* fields are always None.
 
@@ -151,6 +157,54 @@ class LegacySiteTableProcessor(SiteTableProcessor):
         result["PatchId"] = merged["state_index"].values
 
         return result
+
+    @staticmethod
+    def _first_after_choice(candidates: _TRewardEvents, *, choice_time: float, what: str) -> _TRewardEvents:
+        """Keep only the first reward event at or after the choice tone.
+
+        ``ForceGiveReward`` was introduced in dataset 0.6.0; before that the experimenter's
+        manual water went through the same code path as an earned reward, emitting the same
+        ``GiveReward`` event, decrementing the same patch bookkeeping and commanding the same
+        valve pulse. A site interval can therefore hold several deliveries that are identical
+        in the record.
+
+        The heuristic: the earned reward is the first delivery to follow the choice tone, since
+        that is what the task's reward-delay timer is started by. Anything else in the interval
+        is assumed to be manual and dropped. With no choice tone in the interval there is
+        nothing to anchor on, so the first delivery is kept.
+
+        This is a heuristic, not ground truth — the two are not separable before 0.6.0.
+        """
+        if len(candidates) <= 1:
+            return candidates
+        after = candidates if np.isnan(choice_time) else candidates[candidates.index >= choice_time]
+        chosen = (after if not after.empty else candidates).iloc[:1]
+        logger.warning(
+            "%d %s events in one site interval; keeping the one at t=%s (first at/after the "
+            "choice tone). The other %d are assumed to be manually delivered — manual and earned "
+            "water are not separable before dataset 0.6.0.",
+            len(candidates),
+            what,
+            chosen.index[0],
+            len(candidates) - 1,
+        )
+        return chosen
+
+    def _select_patch_state_at_reward(  # type: ignore[override]
+        self, candidates: pd.DataFrame, *, choice_time: float, site_start: float, site_stop: float
+    ) -> pd.DataFrame:
+        return self._first_after_choice(candidates, choice_time=choice_time, what="patch-reward-state")
+
+    def _select_reward_onset_time(  # type: ignore[override]
+        self,
+        site_water_delivery: pd.Series,
+        reward_metadata_sliced: pd.DataFrame,
+        *,
+        site_start: float,
+        choice_time: float,
+    ) -> float:
+        chosen = self._first_after_choice(site_water_delivery, choice_time=choice_time, what="water-delivery")
+        return t.cast(float, chosen.index[0])
 
     @staticmethod
     def _parse_friction(dataset: contraqctor.contract.Dataset) -> pd.Series:  # type: ignore[override]

--- a/src/aind_behavior_vr_foraging_packaging/processing/_site_table.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_site_table.py
@@ -134,7 +134,44 @@ class SiteTableProcessor(AbstractProcessor):
         blocks["block_count"] = range(len(blocks))
         return blocks
 
-    def process_to_sites(self) -> list[Site]:  # noqa: C901
+    def _select_patch_state_at_reward(
+        self, candidates: pd.DataFrame, *, choice_time: float, site_start: float, site_stop: float
+    ) -> pd.DataFrame:
+        """Narrow the in-site patch-reward states down to the one belonging to this site.
+
+        From dataset 0.6.0 onwards the experimenter's manual rewards are logged separately, as
+        ``ForceGiveReward``, so only the site's own earned reward can land in the interval and
+        more than one row means the parse is wrong. Overridden by
+        :class:`~._legacy_site_table.LegacySiteTableProcessor`, where manual and earned rewards
+        share a single logging path and cannot be told apart from the record alone.
+        """
+        assert len(candidates) <= 1, (
+            f"Site interval [{site_start}, {site_stop}) booked {len(candidates)} rewards to this patch, "
+            "expected at most one. A site can only be rewarded once, and from dataset 0.6.0 the "
+            "experimenter's manual water is logged separately as ForceGiveReward, so it cannot account "
+            f"for the extras. Reward times: {list(candidates.index)}"
+        )
+        return candidates
+
+    def _select_reward_onset_time(
+        self,
+        site_water_delivery: pd.Series,
+        reward_metadata_sliced: pd.DataFrame,
+        *,
+        site_start: float,
+        choice_time: float,
+    ) -> float:
+        """Pick the valve opening that delivered this site's earned reward.
+
+        ``site_water_delivery`` is guaranteed non-empty by the caller. See
+        :meth:`_select_patch_state_at_reward` for why the legacy processor overrides this.
+        """
+        if len(reward_metadata_sliced) > 1:
+            closest_index = site_water_delivery.index.get_indexer(pd.Index([site_start]), method="nearest")[0]
+            return t.cast(float, site_water_delivery.index[closest_index])
+        return t.cast(float, site_water_delivery.index[0])
+
+    def process_to_sites(self) -> list[Site]:
         """
         Processes sites, patches, and blocks from the dataset and merges them.
         Returns a DataFrame with merged information.
@@ -232,6 +269,10 @@ class SiteTableProcessor(AbstractProcessor):
             site_choice_feedback = slice_by_index(choice_feedback, this_timestamp, next_timestamp)
             assert len(site_choice_feedback) <= 1, "Multiple speaker choices in site interval"
 
+            choice_time: float = (
+                t.cast(float, site_choice_feedback.index[0]) if not site_choice_feedback.empty else np.nan
+            )
+
             site_odor_onset = slice_by_index(odor_onset, this_timestamp, next_timestamp)
             site_force_reward = slice_by_index(manual_water_delivery, this_timestamp, next_timestamp)
 
@@ -243,14 +284,15 @@ class SiteTableProcessor(AbstractProcessor):
             site_patch_state_at_reward = site_patch_state_at_reward[
                 site_patch_state_at_reward["PatchId"] == merged.iloc[i]["patch_index"]
             ]
-            assert len(site_patch_state_at_reward) <= 1, "Multiple patch states at reward in site interval"
+            site_patch_state_at_reward = self._select_patch_state_at_reward(
+                site_patch_state_at_reward,
+                choice_time=choice_time,
+                site_start=this_timestamp,
+                site_stop=next_timestamp,
+            )
 
             ##
             row = merged.iloc[i]
-
-            choice_time: float = (
-                t.cast(float, site_choice_feedback.index[0]) if not site_choice_feedback.empty else np.nan
-            )
 
             # Compute last_stop_time, last_stop_duration, velocity_at_last_stop
             # We skip calculation if no choice_time was found or IsStopped data is unavailable
@@ -315,12 +357,12 @@ class SiteTableProcessor(AbstractProcessor):
                     else:
                         logger.error("Valid reward metadata found but no water delivery in site interval")
                         reward_onset_time = np.nan
-                elif len(reward_metadata_sliced) > 1:
-                    closest_index = site_water_delivery.index.get_indexer([this_timestamp], method="nearest")[0]
-                    reward_onset_time = t.cast(float, site_water_delivery.index[closest_index])
                 else:
-                    reward_onset_time = (
-                        t.cast(float, site_water_delivery.index[0]) if not site_water_delivery.empty else np.nan
+                    reward_onset_time = self._select_reward_onset_time(
+                        site_water_delivery,
+                        reward_metadata_sliced,
+                        site_start=this_timestamp,
+                        choice_time=choice_time,
                     )
 
             wait_reward_outcome_sliced = slice_by_index(wait_reward_outcome, this_timestamp, next_timestamp)


### PR DESCRIPTION
## Problem

The `sites` parser crashed on legacy datasets with: `AssertionError: Multiple patch states at reward in site interval`.

## Cause

Pre-0.6.0 datasets logged experimenter-delivered water through the same path as earned
reward — same `GiveReward` event, same patch bookkeeping decrement, same valve pulse
width. `ForceGiveReward`, which separates the two, only arrived in v0.6.0 (Oct 2025),
after every session in this dataset was collected. A site interval can therefore hold
several deliveries that are identical in the record, which the assertion forbids.

## Change

Both in-site reward selections move behind overridable hooks:

- **Base (`SiteTableProcessor`)** — behaviour unchanged. The assertion stays, since from
  0.6.0 more than one row really does mean a bad parse. It now reports the site interval
  and the offending timestamps instead of just restating the predicate.
- **`LegacySiteTableProcessor`** — keeps the first delivery at or after the choice tone. The rest are assumed manual and logged as dropped.

## Verification

Both previously-crashing sessions parse, and the counts tie out exactly:

| session | RewardSites | `has_reward` | raw deliveries | dropped |
|---|---|---|---|---|
| `707349_2024-04-22` | 400 | 63 | 64 | 1 |
| `707349_2024-04-23` | 99 | 89 | 102 | 13 |

Invariant now holds everywhere: 0/63 and 0/89 rewards precede their choice tone.
109 existing tests pass.

## Caveats

- This is a heuristic, not ground truth — manual and earned water are not separable
  before 0.6.0.
- `has_forced_rewards` is `False` for every site in this dataset, since
  `ForceGiveReward` exists in 0 of 1761 sessions.
