### PR TITLE
update aind-nwb-utils dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pynwb>=4.1",
     "scipy",
     "pydantic-settings",
-    "aind-nwb-utils",
+    "aind-nwb-utils>=0.2.9",
 ]
 
 [project.urls]

--- a/tests/integration/datasets.yml
+++ b/tests/integration/datasets.yml
@@ -74,6 +74,14 @@ datasets:
       n_rewards: 103
       n_patches: 291
       n_blocks: 6
+
+  - id: behavior_754559_2024-08-26_09-24-17
+    uri: s3://aind-open-data/behavior_754559_2024-08-26_09-24-17/
+    raise_on_error: false
+    rationale: |
+      Legacy dataset (schema version 0.4.0) for subject 754559.
+      Also tests creation of nwb with v1 metadata using jsons in bucket
+
   - id: 716458_2024-05-13_09-03-55
     uri: s3://aind-open-data/716458_2024-05-13_09-03-55/
     raise_on_error: false

--- a/uv.lock
+++ b/uv.lock
@@ -124,7 +124,7 @@ docs = [
 
 [[package]]
 name = "aind-nwb-utils"
-version = "0.2.8"
+version = "0.2.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fsspec" },
@@ -134,9 +134,9 @@ dependencies = [
     { name = "s3fs" },
     { name = "xarray" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/dd/f8/f4e66fd3d1c549f24d127de0772f2f23351da644589b7bdf214123bd7242/aind_nwb_utils-0.2.8.tar.gz", hash = "sha256:2467dfc0b4b2e2d8bd2ed7a1c40658c8f10b262b8b598b4adb483c934b7b5870", size = 39201420, upload-time = "2026-07-29T00:37:24.079Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/80/9f/0309c43b60837e80817191885683cbb90173d4ec38adc4303e885bd1a971/aind_nwb_utils-0.2.9.tar.gz", hash = "sha256:9530430613e05de58779c1bdda82d1f026fb49a6416aeb75c64bc8981540c355", size = 39203302, upload-time = "2026-08-11T19:32:46.159Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/79/fcbc53898cff1ed891556c04af227a12a5bcc0816a5c836cc459eb0a9279/aind_nwb_utils-0.2.8-py3-none-any.whl", hash = "sha256:526aad95a8b34824be4dbdc7e8297c0845f709a843af53bd4d51101d820a919c", size = 14622, upload-time = "2026-07-29T00:37:22.382Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/dc/c26b2a94d23c77aca4666645713dcb393daac8a2879b4757aba439b0c30a/aind_nwb_utils-0.2.9-py3-none-any.whl", hash = "sha256:a21dd3ef945b8d9a2bbe5f46e3234e647f1957f88fa868d44b4e67e0f4fd7f78", size = 14614, upload-time = "2026-08-11T19:32:43.442Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -96,7 +96,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aind-behavior-vr-foraging", extras = ["data"], specifier = ">=1.2.1" },
-    { name = "aind-nwb-utils" },
+    { name = "aind-nwb-utils", specifier = ">=0.2.9" },
     { name = "hdmf-zarr" },
     { name = "numpy", specifier = ">=2" },
     { name = "pandas" },


### PR DESCRIPTION
Attempts to close #54. Tried to bump the version in the lock file and then I also added the offending session to the datasets yml to run integration. Not sure if I did this correctly or if its needed.

Passed when running locally