### PR TITLE
Gracefully handle manual rewards for legacy datasets

### DIFF
--- a/src/aind_behavior_vr_foraging_packaging/processing/_legacy_site_table.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_legacy_site_table.py
@@ -88,6 +88,32 @@ class LegacySiteTableProcessor(SiteTableProcessor):
         logger.debug("Using %s as choice-cue channel.", col)
         return writes[writes[col]]
 
+    def _select_choice_feedback(
+        self,
+        candidates: pd.DataFrame,
+        *,
+        site_index: int,
+        t_start: float,
+        t_end: float,
+    ) -> pd.DataFrame:
+        """Tolerate duplicate choice-cue pulses seen in pre-0.6.0 Harp data.
+
+        This was only identified in a single session (behavior_754570_2024-09-06_10-58-52)
+        and is not intended to be maintained as a fix in the stable version.
+        """
+        if len(candidates) > 1:
+            logger.warning(
+                "Site %d: %d speaker-choice events in interval [%.3f, %.3f); "
+                "keeping first (Harp double-trigger). Timestamps: %s",
+                site_index,
+                len(candidates),
+                t_start,
+                t_end,
+                candidates.index.tolist(),
+            )
+            return candidates.iloc[:1]
+        return candidates
+
     def _get_olfactometer_channel_count(self, dataset: contraqctor.contract.Dataset) -> int:
         return _LEGACY_OLFACTOMETER_CHANNEL_COUNT
 

--- a/src/aind_behavior_vr_foraging_packaging/processing/_site_table.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_site_table.py
@@ -171,6 +171,27 @@ class SiteTableProcessor(AbstractProcessor):
             return t.cast(float, site_water_delivery.index[closest_index])
         return t.cast(float, site_water_delivery.index[0])
 
+    def _select_choice_feedback(
+        self,
+        candidates: pd.DataFrame,
+        *,
+        site_index: int,
+        t_start: float,
+        t_end: float,
+    ) -> pd.DataFrame:
+        """Validate and return the choice-feedback events for a single site interval.
+
+        The base implementation enforces that at most one choice-cue event falls inside
+        the interval — a violation indicates a parse or hardware problem and raises.
+        Override in subclasses (e.g. :class:`~._legacy_site_table.LegacySiteTableProcessor`)
+        to handle known hardware quirks gracefully.
+        """
+        assert len(candidates) <= 1, (
+            f"Multiple speaker choices in site interval [{t_start}, {t_end}); "
+            f"site index {site_index}, timestamps: {candidates.index.tolist()}"
+        )
+        return candidates
+
     def process_to_sites(self) -> list[Site]:
         """
         Processes sites, patches, and blocks from the dataset and merges them.
@@ -267,7 +288,9 @@ class SiteTableProcessor(AbstractProcessor):
             this_patch = merged.iloc[i]["patch_data"]
 
             site_choice_feedback = slice_by_index(choice_feedback, this_timestamp, next_timestamp)
-            assert len(site_choice_feedback) <= 1, "Multiple speaker choices in site interval"
+            site_choice_feedback = self._select_choice_feedback(
+                site_choice_feedback, site_index=i, t_start=this_timestamp, t_end=next_timestamp
+            )
 
             choice_time: float = (
                 t.cast(float, site_choice_feedback.index[0]) if not site_choice_feedback.empty else np.nan


### PR DESCRIPTION
# Tolerate Harp double-trigger choice-cue in legacy site table

The Harp Behavior board occasionally writes the PWM choice-cue signal twice in rapid succession in pre-0.6.0 datasets. The base SiteTableProcessor asserts at most one choice-cue event per site interval; this hard assert caused behavior_754570_2024-09-06_10-58-52 to fail site-table processing entirely.

## Changes:

_site_table.py: extracted the choice-feedback guard into an overridable _select_choice_feedback() hook; base class keeps the strict assert
_legacy_site_table.py: overrides the hook to log a warning and keep only the first event (the true choice onset), consistent with how duplicate reward events are already handled
This was only identified in a single session and is not intended to be maintained as a fix in the stable version.