### PR TITLE
Ensure version metadata is propagated to metadata table

### DIFF
--- a/src/aind_behavior_vr_foraging_packaging/models.py
+++ b/src/aind_behavior_vr_foraging_packaging/models.py
@@ -90,11 +90,18 @@ class SessionMetadata(BaseModel):
     """
 
     session_id: str = Field(description="Session folder name (AIND naming convention).")
-    subject_id: str | None = Field(
-        default=None,
-        description="Subject identifier parsed from the session folder name. None when the name cannot be parsed.",
+    subject_id: str = Field(
+        description="Subject identifier loaded from the session metadata (session_output.json or contraqctor stream).",
     )
-    date: datetime.date | None = Field(
-        default=None,
-        description="Session date parsed from the session folder name. None when the name cannot be parsed.",
+    date: datetime.date = Field(
+        description="Session date loaded from the session metadata (session_output.json or contraqctor stream).",
+    )
+    dataset_version: str = Field(
+        description="Dataset schema version recorded in the session (from tasklogic_input.json).",
+    )
+    data_contract_version: str = Field(
+        description="Version of the aind-behavior-vr-foraging data-contract library used to parse this session.",
+    )
+    packaging_version: str = Field(
+        description="Version of the aind-behavior-vr-foraging-packaging library that produced this output.",
     )

--- a/src/aind_behavior_vr_foraging_packaging/models.py
+++ b/src/aind_behavior_vr_foraging_packaging/models.py
@@ -93,8 +93,8 @@ class SessionMetadata(BaseModel):
     subject_id: str = Field(
         description="Subject identifier loaded from the session metadata (session_output.json or contraqctor stream).",
     )
-    date: datetime.date = Field(
-        description="Session date loaded from the session metadata (session_output.json or contraqctor stream).",
+    date: datetime.datetime = Field(
+        description="Session start datetime loaded from the session metadata (session_output.json or contraqctor stream).",
     )
     dataset_version: str = Field(
         description="Dataset schema version recorded in the session (from tasklogic_input.json).",

--- a/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pandas as pd
 
 from .._base import AbstractProcessor
+from .._provenance import PackagingProvenance
 from ..models import SessionMetadata
 
 logger = logging.getLogger(__name__)
@@ -42,7 +43,7 @@ class SessionMetadataProcessor(AbstractProcessor):
         raw = self._fetch_stream_raw()
         if raw is None:
             raw = self._fetch_json_raw()  # FileNotFoundError if absent
-        row = self._build_metadata(folder_name, raw)
+        row = self._build_metadata(folder_name, raw, self.provenance)
         return pd.DataFrame([row.model_dump()])
 
     # ------------------------------------------------------------------
@@ -64,7 +65,7 @@ class SessionMetadataProcessor(AbstractProcessor):
             return json.load(fh)
 
     @staticmethod
-    def _build_metadata(folder_name: str, raw: dict) -> SessionMetadata:
+    def _build_metadata(folder_name: str, raw: dict, provenance: PackagingProvenance) -> SessionMetadata:
         """Extract required ``subject_id`` and ``date`` from a raw session dict.
 
         Raises :exc:`KeyError` if either field is absent.
@@ -77,4 +78,7 @@ class SessionMetadataProcessor(AbstractProcessor):
             session_id=folder_name,
             subject_id=str(raw["subject"]),
             date=datetime.date.fromisoformat(str(raw["date"])[:10]),
+            dataset_version=provenance.dataset_version,
+            data_contract_version=provenance.data_contract_version,
+            packaging_version=provenance.packaging_version,
         )

--- a/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
@@ -77,7 +77,7 @@ class SessionMetadataProcessor(AbstractProcessor):
         return SessionMetadata(
             session_id=folder_name,
             subject_id=str(raw["subject"]),
-            date=datetime.date.fromisoformat(str(raw["date"])[:10]),
+            date=datetime.datetime.fromisoformat(str(raw["date"])),
             dataset_version=provenance.dataset_version,
             data_contract_version=provenance.data_contract_version,
             packaging_version=provenance.packaging_version,

--- a/tests/processing/test_session_metadata.py
+++ b/tests/processing/test_session_metadata.py
@@ -54,7 +54,7 @@ def test_reads_from_stream(tmp_path):
     assert len(df) == 1
     assert set(df.columns) >= {"session_id", "subject_id", "date"}
     assert df["subject_id"].iloc[0] == "815103"
-    assert df["date"].iloc[0] == datetime.date(2025, 11, 5)
+    assert df["date"].iloc[0] == datetime.datetime(2025, 11, 5, 22, 52, 21, tzinfo=datetime.timezone.utc)
 
 
 def test_stream_integer_subject_coerced_to_str(tmp_path):
@@ -100,7 +100,7 @@ def test_falls_back_to_json_when_stream_fails(tmp_path):
     proc = SessionMetadataProcessor(ds, session_path=tmp_path)
     df = proc._compute()
     assert df["subject_id"].iloc[0] == "815103"
-    assert df["date"].iloc[0] == datetime.date(2025, 11, 5)
+    assert df["date"].iloc[0] == datetime.datetime(2025, 11, 5, 22, 52, 21, tzinfo=datetime.timezone.utc)
 
 
 def test_json_integer_subject_coerced(tmp_path):
@@ -119,7 +119,7 @@ def test_legacy_version_fallback_reads_json(tmp_path):
     proc = SessionMetadataProcessor(ds, session_path=tmp_path)
     df = proc._compute()
     assert df["subject_id"].iloc[0] == "716458"
-    assert df["date"].iloc[0] == datetime.date(2024, 5, 13)
+    assert df["date"].iloc[0] == datetime.datetime(2024, 5, 13, 9, 3, 55, tzinfo=datetime.timezone.utc)
 
 
 def test_json_missing_subject_raises(tmp_path):


### PR DESCRIPTION
## Add provenance fields to `session.parquet` and fix `SessionMetadata` model

### What

- **`session.parquet` now includes three provenance columns**: `dataset_version`, `data_contract_version`, and `packaging_version` — the same version strings already written to every parquet's `df.attrs`, now surfaced as first-class queryable columns.
- **`SessionMetadata` model corrections**:
  - `subject_id` and `date` are now required fields (they were `| None` with a default, but `_build_metadata` raises before constructing the model if either is absent — the optionality was unreachable).
  - `date` is now `datetime.datetime` instead of `datetime.date`; the raw `session_output.json` field is a full ISO-8601 string with timezone (e.g. `2024-09-06T10:58:52.781903-07:00`) — the previous `[:10]` truncation was silently discarding the time and timezone.
  - Field descriptions corrected: `subject_id` and `date` are loaded from `session_output.json` / contraqctor stream, not parsed from the folder name.

### Why

Provenance information was only stored in parquet file metadata (`df.attrs`), inaccessible to DuckDB / Polars / R queries without special handling. Putting the versions in columns makes it trivial to filter or group sessions by schema or packaging version — useful for tracking which sessions need re-export after a pipeline update.

### Changes

| File | Change |
|---|---|
| `models.py` | Add `dataset_version`, `data_contract_version`, `packaging_version`; make `subject_id`/`date` required; `date → datetime.datetime` |
| `processing/_session_metadata.py` | Thread `PackagingProvenance` into `_build_metadata`; fix date parser |
| `tests/processing/test_session_metadata.py` | Update date assertions to `datetime.datetime` with UTC timezone |
