### PR TITLE
Add session, rig, and task_logic to `session.parquet`

### DIFF
--- a/docs/knowledge/architecture/batch.md
+++ b/docs/knowledge/architecture/batch.md
@@ -4,7 +4,7 @@ title: Batch pipeline — many sessions to a queryable export
 description: pipeline/batch.py runs the session pipeline over many session directories, writes per-session parquets, optionally writes one NWB-Zarr store per session, and concatenates chosen tables into flat per-experiment parquet files; driven by the vr-foraging-packaging CLI.
 resource: src/aind_behavior_vr_foraging_packaging/pipeline/batch.py
 tags: [architecture, pipeline, parquet, nwb, export, cli, aggregation]
-timestamp: 2026-08-16T00:00:00Z
+timestamp: 2026-08-30T00:00:00Z
 ---
 
 `pipeline/batch.py` is the multi-session layer above [session.md](session.md).
@@ -158,12 +158,16 @@ show DuckDB queries over a local and an S3-hosted export respectively.
 ## Provenance does not survive Phase 2
 
 The per-session files carry the packaging/parser/dataset versions in their
-parquet schema metadata, because Phase 1 writes them with `_write_parquet`
-(see [session.md](session.md)). Phase 2 uses the same writer,
-but the **aggregated** files still carry nothing: `pd.concat` keeps `df.attrs`
-only when every input frame agrees, and `dataset_version` differs across
-sessions by design, so the concatenated frame's attrs are empty before the write
-even happens.
+parquet schema metadata, because Phase 1 writes them via each processor's
+`write_parquet()` (see [session.md](session.md) and
+[processor-abstraction.md](processor-abstraction.md)). Phase 2 writes the
+concatenated frame with the plain module-level `_base.write_parquet`, not
+through any processor instance — there is no live per-session dataset left to
+construct one from, only rows already read back off disk — so the
+**aggregated** files still carry no schema-metadata provenance: `pd.concat`
+keeps `df.attrs` only when every input frame agrees, and `dataset_version`
+differs across sessions by design, so the concatenated frame's attrs are empty
+before the write even happens.
 
 `session.parquet` is the exception, and deliberately so: `SessionMetadata`
 carries `dataset_version`, `data_contract_version` and `packaging_version` as
@@ -171,6 +175,14 @@ ordinary **columns**, not attrs, so they survive `pd.concat` and the write like
 any other data. That is the whole point — it is the one aggregate where
 per-session provenance is recoverable, and it is joinable to every other table
 on `session_id`.
+
+One more thing this same gap costs: `SessionMetadataProcessor.write_parquet`'s
+tagging of `session`/`rig`/`task_logic` with Parquet's native `JSON` logical
+type (see [session.md](session.md)) is a *processor* behavior, so it applies
+only to the per-session `session.parquet` files, never to the aggregated one —
+Phase 2 writes those three columns as plain string columns. The JSON *text*
+itself is unaffected and still parses; only the logical-type tag is
+per-session-only.
 
 Everywhere else, provenance lives in the per-session files, which Phase 2 never
 deletes. An export therefore stays auditable at the row level without anyone

--- a/docs/knowledge/architecture/data-contract-and-versioning.md
+++ b/docs/knowledge/architecture/data-contract-and-versioning.md
@@ -4,7 +4,7 @@ title: Data contract, Harp streams, and the three versions
 description: How the library reads sessions via contraqctor/aind-behavior-vr-foraging, the three semver versions it tracks and dispatches on, and where each lands in the parquet and NWB outputs.
 resource: src/aind_behavior_vr_foraging_packaging/_provenance.py
 tags: [architecture, data-contract, contraqctor, harp, semver, versioning, provenance]
-timestamp: 2026-08-09T00:00:00Z
+timestamp: 2026-08-30T00:00:00Z
 ---
 
 Processors never touch raw files directly. They read through a **data
@@ -28,7 +28,8 @@ Dataset
     ├── "HarpLickometer"  → LickState
     ├── "HarpSniffDetector"→ RawVoltage
     ├── "OperationControl"→ IsStopped
-    └── "InputSchemas"    → Rig (calibration & configuration)
+    └── "InputSchemas"    → Session, Rig, TaskLogic (raw config, read verbatim
+                             by SessionMetadataProcessor — see session.md)
 ```
 
 Harp streams carry a `MessageType` column (`WRITE` / `EVENT`); processors
@@ -69,7 +70,7 @@ them and the integration suite can assert they agree:
 
 | Output | Location | Written by |
 |--------|----------|------------|
-| Parquet | `df.attrs`, plus the same keys as top-level parquet schema metadata (readable from DuckDB, Polars, R arrow — no pandas needed) | `AbstractProcessor.compute` stamps the attrs; `pipeline.session._write_parquet` promotes them |
+| Parquet | `df.attrs`, plus the same keys as top-level parquet schema metadata (readable from DuckDB, Polars, R arrow — no pandas needed) | `AbstractProcessor.compute` stamps the attrs; `AbstractProcessor.write_parquet` (see [processor-abstraction.md](processor-abstraction.md)) promotes them |
 | NWB | `nwb.was_generated_by`, appended to the entry `create_base_nwb_file` already wrote | `NwbSession._create_nwb_file` |
 
 Parquet additionally carries a `processor` key naming the class that produced
@@ -84,12 +85,14 @@ dict(nwb.was_generated_by[:])   # includes aind-nwb-utils' own entry alongside o
 Why they live in `was_generated_by`, and the write-once constraint that comes
 with it, is covered in [nwb-packaging.md](nwb-packaging.md).
 
-One gap to know about: these keys are **per-session**, and
-[Phase 2 aggregation](batch.md) does not carry them onto the flat
-experiment-level tables — nor does the aggregated `session.parquet`, whose
-model has no version columns. A multi-session export is currently not
-self-describing; that section documents exactly where provenance is and is not
-retained.
+One gap to know about: these keys are **per-session** `df.attrs`, and
+[Phase 2 aggregation](batch.md) does not carry *those* onto the flat
+experiment-level tables. `session.parquet` is the one aggregate that keeps its
+provenance regardless — `SessionMetadata` carries `dataset_version`,
+`data_contract_version` and `packaging_version` as ordinary columns rather than
+attrs, so they survive `pd.concat` — but every other aggregated table is not
+self-describing; see [batch.md](batch.md) for exactly where provenance is and
+is not retained.
 
 ## PEP 440 → SemVer
 

--- a/docs/knowledge/architecture/processor-abstraction.md
+++ b/docs/knowledge/architecture/processor-abstraction.md
@@ -1,10 +1,10 @@
 ---
 type: Component
 title: AbstractProcessor — the processor contract
-description: The abstract base class every processor implements; defines compute()/_compute(), nwbize(), output_name, provenance stamping, and the opt-in cached_frame decorator.
+description: The abstract base class every processor implements; defines compute()/_compute(), nwbize(), write_parquet(), output_name, provenance stamping, and the opt-in cached_frame decorator.
 resource: src/aind_behavior_vr_foraging_packaging/_base.py
-tags: [architecture, processor, base-class, contract, provenance, caching]
-timestamp: 2026-08-16T00:00:00Z
+tags: [architecture, processor, base-class, contract, provenance, caching, parquet]
+timestamp: 2026-08-30T00:00:00Z
 ---
 
 Every unit of parsing logic is a subclass of `AbstractProcessor`
@@ -21,6 +21,7 @@ The contract a subclass must satisfy and may extend:
 | `_compute(self) -> pd.DataFrame` | **abstract** | The real work. Return the output DataFrame. Never call directly from outside. |
 | `compute(self) -> pd.DataFrame` | concrete | Calls `_compute`, then stamps provenance into `df.attrs`. This is the public entry point. |
 | `nwbize(self, nwb_file) -> nwb_file` | concrete (no-op default) | Write this processor's data into an NWB file. Override where an NWB representation exists. |
+| `write_parquet(self, output_dir, filename=None)` | concrete | Calls `compute()` internally and writes `output_dir/(filename or f"{output_name}.parquet")`, promoting `df.attrs` into parquet schema metadata. Override wholesale to customize the arrow table before it's written — `SessionMetadataProcessor` is the one processor that does, tagging its `Json[...]` fields with Parquet's native `JSON` logical type (see [session.md](session.md)). |
 | `__output_name__: ClassVar[str \| None]` | class attr | Canonical parquet filename stem (e.g. `"sites"`). |
 | `output_name` | property | `__output_name__` if set, else snake_case of the class name. |
 | `dataset` | property | The loaded contraqctor Dataset. |
@@ -52,9 +53,13 @@ R arrow, Spark, etc. See [session.md](session.md).
 
 # `cached_frame` — opt-in memoization
 
-`compute()` and `nwbize()` share no state, and every `nwbize()` implementation
-re-enters `compute()`. Under `--write-nwb` that means each frame is built twice.
-`cached_frame` is a decorator applied to `_compute` to remove the second build:
+`compute()`, `nwbize()` and `write_parquet()` share no state, and both
+`nwbize()` and the default `write_parquet()` re-enter `compute()` independently
+of whatever the caller already computed. `pipeline.session.process_session`
+already calls `compute()` once for the frame it returns, so `write_parquet()`
+re-entering it means every processor risks a second (or third, under
+`--write-nwb`) full `_compute()` per session. `cached_frame` is a decorator
+applied to `_compute` to remove the rebuild:
 
 ```python
 from .._base import AbstractProcessor, cached_frame
@@ -65,11 +70,15 @@ class LicksProcessor(AbstractProcessor):
     def _compute(self) -> pd.DataFrame: ...
 ```
 
-It is **opt-in per processor**, not built into `AbstractProcessor`, because two
-of the seven gain nothing: `SoftwareEventsProcessor` builds its NWB tables
-straight from the raw streams, and `SessionMetadataProcessor` has no `nwbize` at
-all. The other five use it; the two legacy subclasses inherit `_compute`
-unchanged and so inherit the caching too.
+Still opt-in per processor rather than built into `AbstractProcessor` — but
+since `write_parquet()` re-entering `compute()` now applies to *every*
+processor's default parquet-writing path (not only `nwbize()` under
+`--write-nwb`), all seven currently decorate `_compute` with it, including
+`SessionMetadataProcessor` and `SoftwareEventsProcessor`, which used to be the
+two holdouts (`SoftwareEventsProcessor` builds its NWB tables straight from the
+raw streams, bypassing `compute()`, and `SessionMetadataProcessor` had no
+`nwbize` at all — neither gained anything until `write_parquet()` started
+re-entering `compute()` too).
 
 Two properties keep it from weakening the contract above:
 
@@ -109,9 +118,11 @@ from `processing/__init__.py`.
 
 # Design notes
 
-- `compute()` and `nwbize()` are intentionally independent — no shared state.
-  `nwbize()` may call `compute()` internally, but neither depends on the other
-  having run. `cached_frame` preserves this, since it hands back a copy.
+- `compute()`, `nwbize()` and `write_parquet()` are intentionally independent
+  of one another and of whatever the caller already computed. `nwbize()` and
+  the default `write_parquet()` may call `compute()` internally, but none of
+  the three depends on another having run. `cached_frame` preserves this,
+  since it hands back a copy on every call.
 - Keeping one output per processor is what makes the fan-out in
   [session.md](session.md) trivial and makes each output independently
   testable.

--- a/docs/knowledge/architecture/session.md
+++ b/docs/knowledge/architecture/session.md
@@ -1,10 +1,10 @@
 ---
 type: Component
 title: Session pipeline — version dispatch, fan-out, and parquet output
-description: pipeline/session.py selects the correct processor set for a dataset version, runs them over one session via process_session, and writes provenance-stamped parquet files.
+description: pipeline/session.py selects the correct processor set for a dataset version, runs them over one session via process_session, and calls each processor's write_parquet() to produce provenance-stamped parquet files.
 resource: src/aind_behavior_vr_foraging_packaging/pipeline/session.py
-tags: [architecture, pipeline, parquet, version-dispatch]
-timestamp: 2026-08-16T00:00:00Z
+tags: [architecture, pipeline, parquet, version-dispatch, json]
+timestamp: 2026-08-30T00:00:00Z
 ---
 
 `pipeline/session.py` is the thin orchestration layer for **one** session. It
@@ -39,6 +39,18 @@ dataset-level filtering: `session_id` is the session directory's name, while
 stream. The stream's own `session_name` field is ignored — it is `null` on
 pre-0.6 datasets and, where populated, formatted differently from the
 directory that every other layer keys on.
+
+It also carries the raw `Behavior/InputSchemas/{Session,Rig,TaskLogic}`
+streams **verbatim**, one JSON-text column each (`SessionMetadata.session`,
+`.rig`, `.task_logic` — pydantic `Json[Any]` fields), so the full session/rig/
+task-logic config is discoverable straight from `session.parquet` without a
+second pass over the dataset. Legacy (`< 1.0`) schema versions read these as
+plain `Json` streams (already a dict); current versions read them as
+`PydanticModel`s and `model_dump(mode="json")` them first — either way the
+column ends up holding the same JSON text. See
+[processor-abstraction.md](processor-abstraction.md) for `write_parquet()`,
+which is how these three columns end up tagged with Parquet's native `JSON`
+logical type rather than an opaque string (below).
 
 Two convenience getters return a single version-correct processor without
 building the whole list:
@@ -88,7 +100,8 @@ Log lines are prefixed with `[{session_id}]`, taken from the dataset via
 batch run without the caller having to pass a label down.
 
 1. Creates `output_dir` if either writer is enabled.
-2. For each processor, calls `compute()` and, when `write_parquet`, writes
+2. For each processor, calls `compute()` and, when `write_parquet`, calls
+   `proc.write_parquet(output_dir)`, which writes
    `output_dir/<output_name>.parquet`.
 3. When `write_nwb`, writes `output_dir/behavior.nwb.zarr`.
 4. Returns `dict[str, pd.DataFrame]` keyed by `output_name`.
@@ -129,12 +142,21 @@ returning normally skips that processor, re-raising aborts. It defaults to
 
 # Provenance in parquet
 
-`_write_parquet` promotes every key in `df.attrs` (see
-[processor-abstraction.md](processor-abstraction.md)) into the parquet schema
-metadata **twice**: inside the pandas metadata blob (for pandas round-trips)
-and as top-level key/value entries (readable from DuckDB, Polars, R arrow,
-Spark). This is why provenance is not lost when a downstream tool reads the
-file without pandas.
+`AbstractProcessor.write_parquet` (see
+[processor-abstraction.md](processor-abstraction.md)) promotes every key in
+`df.attrs` into the parquet schema metadata **twice**: inside the pandas
+metadata blob (for pandas round-trips) and as top-level key/value entries
+(readable from DuckDB, Polars, R arrow, Spark). This is why provenance is not
+lost when a downstream tool reads the file without pandas.
+
+`SessionMetadataProcessor` overrides `write_parquet` wholesale: it computes
+`SessionMetadata`'s `Json[...]` field names by introspecting
+`SessionMetadata.model_fields` (currently `session`, `rig`, `task_logic`), then
+casts each of those columns to pyarrow's `pa.json_()` type before writing.
+Parquet writes that as `BYTE_ARRAY` with the *native* `JSON` logical type — not
+just Arrow-side extension metadata — so a JSON-aware reader (e.g. DuckDB) sees
+real JSON rather than an opaque string. It falls back to the default writer on
+a pyarrow build without `json_` (added in pyarrow 19).
 
 # Examples
 

--- a/docs/knowledge/log.md
+++ b/docs/knowledge/log.md
@@ -3,6 +3,44 @@
 Chronological history of changes to this knowledge bundle, newest first.
 Add an entry here whenever you add, remove, or materially revise a concept.
 
+## 2026-08-30 (session.parquet carries raw session/rig/task_logic; `write_parquet()` joins `compute()`/`nwbize()`)
+
+* **Schema**: `SessionMetadata` (`models.py`) gained three `Json[Any]` fields —
+  `session`, `rig`, `task_logic` — carrying the contraqctor
+  `Behavior/InputSchemas/{Session,Rig,TaskLogic}` streams verbatim, so the full
+  raw config is discoverable straight from `session.parquet` without a second
+  pass over the dataset (issue #63). Legacy (`< 1.0`) schema versions read
+  these streams as plain dicts; current versions read `PydanticModel`s and
+  `model_dump(mode="json")` them first — either path lands as the same JSON
+  text.
+* **Architecture**: `AbstractProcessor` gained a third concrete, overridable
+  method — `write_parquet(self, output_dir, filename=None)` — alongside
+  `compute()` and `nwbize()`. Like `nwbize()`, its default implementation calls
+  `compute()` internally rather than taking a DataFrame, so all three methods
+  stay independent (no shared state). See
+  [processor-abstraction.md](architecture/processor-abstraction.md).
+* **Architecture**: `SessionMetadataProcessor` overrides `write_parquet`
+  wholesale: it introspects `SessionMetadata.model_fields` for `Json[...]`
+  fields and casts each to pyarrow's `pa.json_()` type before writing. Verified
+  by round-trip that Parquet writes this as `BYTE_ARRAY` with the *native*
+  `JSON` logical type (`pq.ParquetFile(...).schema`), not just an Arrow-side
+  extension — readable as real JSON by e.g. DuckDB. This tagging is
+  per-session only: Phase 2 aggregation writes the concatenated `session`
+  table through the plain module-level `write_parquet`, since there is no
+  live per-session processor instance to dispatch through — see
+  [batch.md](architecture/batch.md).
+* **Architecture**: because `write_parquet()`'s default now re-enters
+  `compute()` on every `write_parquet=True` run (not only under
+  `--write-nwb`, which is what `nwbize()` re-entering `compute()` used to
+  cost), `cached_frame` moved from opt-in-for-five to applied on all seven
+  processors — `SessionMetadataProcessor` and `SoftwareEventsProcessor` were
+  the two holdouts and now decorate `_compute` too.
+* Fixed a pre-existing contradiction between
+  [data-contract-and-versioning.md](architecture/data-contract-and-versioning.md)
+  and [batch.md](architecture/batch.md) over whether `session.parquet`'s model
+  carries version columns (it does — see batch.md's "Provenance does not
+  survive Phase 2").
+
 ## 2026-08-16 (scoped `clean`)
 
 * **Architecture**: `process_sessions(clean=True)` no longer does

--- a/src/aind_behavior_vr_foraging_packaging/_base.py
+++ b/src/aind_behavior_vr_foraging_packaging/_base.py
@@ -56,19 +56,16 @@ def cached_frame(fn: ty.Callable[[ty.Any], pd.DataFrame]) -> ty.Callable[[ty.Any
     Opt-in per processor — deliberately *not* applied by :class:`AbstractProcessor`
     to everything. Decorate ``_compute`` only where both hold:
 
-    1. ``nwbize()`` re-enters ``compute()``, so the frame is built twice per
-       session whenever ``--write-nwb`` is set, and
+    1. ``nwbize()`` and/or ``write_parquet()`` re-enter ``compute()`` independently
+       of whatever the caller already computed, so the frame can be built more
+       than once per session, and
     2. building it is expensive enough for that to matter.
 
-    Five of the seven processors qualify; ``SoftwareEventsProcessor`` builds its
-    NWB tables straight from the raw streams and ``SessionMetadataProcessor`` has
-    no ``nwbize`` at all, so neither gains anything.
-
-    Each call returns a **copy**, so the invariant documented on
-    :meth:`AbstractProcessor.nwbize` — that ``compute()`` and ``nwbize()`` share
-    no state — still holds exactly. Callers may mutate what they get back without
-    reaching into the cache or into each other. Copying a frame is far cheaper
-    than re-parsing the underlying streams, so the saving survives.
+    Each call returns a **copy**, so the invariant that ``compute()``,
+    ``nwbize()`` and ``write_parquet()`` share no state still holds exactly.
+    Callers may mutate what they get back without reaching into the cache or
+    into each other. Copying a frame is far cheaper than re-parsing the
+    underlying streams, so the saving survives.
 
     The cache lives on the instance (``self.__dict__``), and processors are
     constructed per session by
@@ -88,6 +85,28 @@ def cached_frame(fn: ty.Callable[[ty.Any], pd.DataFrame]) -> ty.Callable[[ty.Any
         return cache[key].copy()
 
     return wrapper
+
+
+def write_parquet(df: pd.DataFrame, path: Path) -> None:
+    """Write *df* to *path* as parquet, promoting ``df.attrs`` to schema metadata.
+
+    All keys in ``df.attrs`` are written both in the pandas metadata blob
+    (for pandas round-trips) and as top-level key-value entries in the parquet
+    schema (readable from DuckDB, R arrow, Polars, Spark, etc.).
+
+    The canonical implementation, usable directly by callers with no processor
+    instance at hand — e.g. :mod:`~aind_behavior_vr_foraging_packaging.pipeline.batch`'s
+    multi-session aggregation, which reads parquets back from disk and
+    re-combines them — and it's also :meth:`AbstractProcessor.write_parquet`'s
+    default implementation, overridable per processor.
+    """
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    table = pa.Table.from_pandas(df)
+    kv = {str(k).encode(): str(v).encode() for k, v in df.attrs.items()}
+    table = table.replace_schema_metadata({**table.schema.metadata, **kv})
+    pq.write_table(table, path)
 
 
 class AbstractProcessor(abc.ABC):
@@ -152,17 +171,33 @@ class AbstractProcessor(abc.ABC):
         """Write this processor's output to *nwb_file* and return it.
 
         Default implementation is a no-op. Override in subclasses that have
-        an NWB representation. May call ``compute()`` internally; the two
-        methods are intentionally independent (no shared state).
+        an NWB representation. May call ``compute()`` internally; ``compute()``,
+        ``nwbize()`` and :meth:`write_parquet` are intentionally independent of
+        one another (no shared state).
 
-        That independence costs a second full ``_compute()`` per session when
-        both outputs are written (``--write-nwb``). Processors for which that
+        That independence costs a second (or third) full ``_compute()`` per
+        session whenever more than one of them runs. Processors for which that
         is expensive decorate ``_compute`` with
         :func:`~aind_behavior_vr_foraging_packaging._base.cached_frame`, which
         removes the recomputation while preserving the no-shared-state
         guarantee — every call still hands back its own copy.
         """
         return nwb_file
+
+    def write_parquet(self, output_dir: Path, filename: str | None = None) -> None:
+        """Compute this processor's output and write it under *output_dir* as parquet.
+
+        Calls :meth:`compute` internally rather than taking a DataFrame — see
+        :meth:`nwbize` for why the output-writing methods are independent of
+        one another and of whatever the caller already computed.
+
+        *filename* defaults to ``f"{self.output_name}.parquet"`` when not given,
+        matching the pipeline's own naming convention. Default implementation
+        delegates to the module-level :func:`write_parquet`. Override wholesale
+        in a subclass to customize the arrow table before it's written — e.g.
+        tagging a column with a non-default logical type.
+        """
+        write_parquet(self.compute(), output_dir / (filename or f"{self.output_name}.parquet"))
 
     def with_strict_parsing(self, strict_parsing: bool = True) -> ty.Self:
         self._strict_parsing = strict_parsing

--- a/src/aind_behavior_vr_foraging_packaging/models.py
+++ b/src/aind_behavior_vr_foraging_packaging/models.py
@@ -1,6 +1,7 @@
 import datetime
+from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, Json
 
 
 class Site(BaseModel):
@@ -106,4 +107,13 @@ class SessionMetadata(BaseModel):
     )
     packaging_version: str = Field(
         description="Version of the aind-behavior-vr-foraging-packaging library that produced this output.",
+    )
+    session: Json[Any] = Field(
+        description="The Session model instance used for the session.",
+    )
+    rig: Json[Any] = Field(
+        description="The Rig model instance used for the session.",
+    )
+    task_logic: Json[Any] = Field(
+        description="The Task Logic model instance used for the session.",
     )

--- a/src/aind_behavior_vr_foraging_packaging/pipeline/batch.py
+++ b/src/aind_behavior_vr_foraging_packaging/pipeline/batch.py
@@ -16,7 +16,8 @@ from pathlib import Path
 
 import pandas as pd
 
-from .session import _write_parquet, process_session
+from .._base import write_parquet
+from .session import process_session
 
 logger = logging.getLogger(__name__)
 
@@ -212,6 +213,6 @@ def _aggregate_table(table: str, session_dirs: list[Path], output_dir: Path) -> 
 
     combined = pd.concat(frames, ignore_index=True)
     dest = output_dir / f"{table}.parquet"
-    _write_parquet(combined, dest)
+    write_parquet(combined, dest)
     logger.info("  %s → %d rows → %s", table, len(combined), dest.name)
     return True

--- a/src/aind_behavior_vr_foraging_packaging/pipeline/session.py
+++ b/src/aind_behavior_vr_foraging_packaging/pipeline/session.py
@@ -237,7 +237,7 @@ def process_session(
             continue
         all_data[name] = df
         if write_parquet:
-            _write_parquet(df, output_dir / f"{name}.parquet")
+            proc.write_parquet(output_dir)
             logger.info("[%s]   saved %d rows → %s.parquet", root.name, len(df), name)
         else:
             logger.info("[%s]   %d rows (parquet skipped)", root.name, len(df))
@@ -275,19 +275,3 @@ def _write_nwb_zarr(
 
     logger.info("[%s] NWB → %s", root.name, dest.name)
     return dest
-
-
-def _write_parquet(df: pd.DataFrame, path: Path) -> None:
-    """Write *df* to *path*, promoting ``df.attrs`` to first-class parquet metadata.
-
-    All keys in ``df.attrs`` are written both in the pandas metadata blob
-    (for pandas round-trips) and as top-level key-value entries in the parquet
-    schema (readable from DuckDB, R arrow, Polars, Spark, etc.).
-    """
-    import pyarrow as pa
-    import pyarrow.parquet as pq
-
-    table = pa.Table.from_pandas(df)
-    kv = {str(k).encode(): str(v).encode() for k, v in df.attrs.items()}
-    table = table.replace_schema_metadata({**table.schema.metadata, **kv})
-    pq.write_table(table, path)

--- a/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
@@ -1,14 +1,15 @@
 """Processor that extracts session-level identity metadata from the dataset's Session log."""
 
 import datetime
+import json
 import logging
-from typing import Any, cast
+from pathlib import Path
+from typing import Any
 
 import pandas as pd
-from pydantic import BaseModel
+from pydantic import BaseModel, Json
 
-from .._base import AbstractProcessor, session_root
-from .._provenance import PackagingProvenance
+from .._base import AbstractProcessor, cached_frame, session_root
 from ..models import SessionMetadata
 
 logger = logging.getLogger(__name__)
@@ -20,31 +21,83 @@ class SessionMetadataProcessor(AbstractProcessor):
     ``session_id`` is always the session directory's name; the stream's own
     ``session_name`` field is ignored. ``subject`` and ``date`` come from the
     contraqctor ``Behavior/InputSchemas/Session`` stream, with no fallback.
+
+    Also carries the raw ``session``, ``rig`` and ``task_logic`` config streams
+    verbatim (see ``SessionMetadata``'s ``Json`` fields), for discoverability
+    without a second pass over the dataset.
     """
 
     __output_name__ = "session"
 
+    @cached_frame
     def _compute(self) -> pd.DataFrame:
-        raw = self._load_session_stream()
-        row = self._build_metadata(raw, session_root(self._dataset).name, self.provenance)
+        session_raw = self._normalize(self._load_input_schema("Session"))
+        self._require_fields(session_raw, "subject", "date")
+        row = SessionMetadata(
+            session_id=session_root(self._dataset).name,
+            subject_id=str(session_raw["subject"]),
+            date=datetime.datetime.fromisoformat(str(session_raw["date"])),
+            dataset_version=self.provenance.dataset_version,
+            data_contract_version=self.provenance.data_contract_version,
+            packaging_version=self.provenance.packaging_version,
+            session=json.dumps(session_raw),
+            rig=json.dumps(self._normalize(self._load_input_schema("Rig"))),
+            task_logic=json.dumps(self._normalize(self._load_input_schema("TaskLogic"))),
+        )
         return pd.DataFrame([row.model_dump()])
 
-    def _load_session_stream(self) -> dict[str, Any]:
-        """Return the Session stream's payload as a plain dict."""
-        data = self._dataset.at("Behavior").at("InputSchemas").at("Session").load().data
-        return data.model_dump() if isinstance(data, BaseModel) else cast(dict[str, Any], data)
+    def _load_input_schema(self, name: str) -> Any:
+        """Return the ``Behavior/InputSchemas/<name>`` stream's raw payload, as loaded.
+
+        Current-schema streams (``>= 1.0``) are ``PydanticModel``s; legacy streams
+        are plain ``Json``, already a dict.
+        """
+        return self._dataset.at("Behavior").at("InputSchemas").at(name).load().data
 
     @staticmethod
-    def _build_metadata(raw: dict, session_id: str, provenance: PackagingProvenance) -> SessionMetadata:
-        """Raises :exc:`KeyError` if ``subject`` or ``date`` is absent or empty."""
-        for field in ("subject", "date"):
+    def _normalize(payload: Any) -> dict[str, Any]:
+        """Normalize a stream payload to a plain, JSON-safe dict.
+
+        Pydantic payloads are dumped with ``mode="json"`` so every field lands as
+        a JSON-native type; the plain-dict (legacy) case is already JSON-safe,
+        having come straight from ``json.load``.
+        """
+        return payload.model_dump(mode="json") if isinstance(payload, BaseModel) else payload
+
+    @staticmethod
+    def _require_fields(raw: dict, *fields: str) -> None:
+        """Raises :exc:`KeyError` if any of *fields* is absent or empty in *raw*."""
+        for field in fields:
             if not raw.get(field):
                 raise KeyError(f"Required field {field!r} missing from the contraqctor Session stream")
-        return SessionMetadata(
-            session_id=session_id,
-            subject_id=str(raw["subject"]),
-            date=datetime.datetime.fromisoformat(str(raw["date"])),
-            dataset_version=provenance.dataset_version,
-            data_contract_version=provenance.data_contract_version,
-            packaging_version=provenance.packaging_version,
+
+    def write_parquet(self, output_dir: Path, filename: str | None = None) -> None:
+        """Compute, then write, tagging ``SessionMetadata``'s ``Json`` fields with Parquet's native JSON logical type.
+
+        Falls back to the default writer on a pyarrow build without ``json_``
+        (added in pyarrow 19).
+        """
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        json_type_factory = getattr(pa, "json_", None)
+        if json_type_factory is None:
+            return super().write_parquet(output_dir, filename)
+
+        df = self.compute()
+        table = pa.Table.from_pandas(df)
+        kv = {str(k).encode(): str(v).encode() for k, v in df.attrs.items()}
+        table = table.replace_schema_metadata({**table.schema.metadata, **kv})
+
+        json_fields = (
+            name
+            for name, field in SessionMetadata.model_fields.items()
+            if any(isinstance(m, Json) for m in field.metadata)
         )
+        for column in json_fields:
+            index = table.schema.get_field_index(column)
+            json_array = pa.array([json.dumps(v) for v in df[column]], type=json_type_factory())
+            table = table.set_column(index, table.field(index).with_type(json_array.type), json_array)
+
+        path = output_dir / (filename or f"{self.output_name}.parquet")
+        pq.write_table(table, path)

--- a/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_session_metadata.py
@@ -92,7 +92,8 @@ class SessionMetadataProcessor(AbstractProcessor):
         json_fields = (
             name
             for name, field in SessionMetadata.model_fields.items()
-            if any(isinstance(m, Json) for m in field.metadata)
+            # pydantic.Json is Annotated[AnyType, ...] under TYPE_CHECKING but a real class at runtime.
+            if any(isinstance(m, Json) for m in field.metadata)  # ty: ignore[invalid-argument-type]
         )
         for column in json_fields:
             index = table.schema.get_field_index(column)

--- a/src/aind_behavior_vr_foraging_packaging/processing/_software_events.py
+++ b/src/aind_behavior_vr_foraging_packaging/processing/_software_events.py
@@ -4,7 +4,7 @@ import typing as ty
 
 import pandas as pd
 
-from .._base import AbstractProcessor
+from .._base import AbstractProcessor, cached_frame
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +28,7 @@ class SoftwareEventsProcessor(AbstractProcessor):
 
     __output_name__ = "software_events"
 
+    @cached_frame
     def _compute(self) -> pd.DataFrame:
         """Returns all software events sorted by timestamp.
 

--- a/tests/pipeline/test_batch.py
+++ b/tests/pipeline/test_batch.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
-from aind_behavior_vr_foraging_packaging._base import session_root
+from aind_behavior_vr_foraging_packaging._base import session_root, write_parquet
 from aind_behavior_vr_foraging_packaging.pipeline.batch import (
     AGGREGATED_TABLES,
     SESSION_TABLE,
@@ -23,6 +23,9 @@ from aind_behavior_vr_foraging_packaging.processing import SessionMetadataProces
 def _mock_proc(name: str, *, raises: bool = False) -> MagicMock:
     proc = MagicMock()
     proc.output_name = name
+    proc.write_parquet.side_effect = lambda output_dir, filename=None: write_parquet(
+        proc.compute(), output_dir / (filename or f"{name}.parquet")
+    )
     if raises:
         proc.compute.side_effect = ValueError(f"{name} blew up")
     else:

--- a/tests/pipeline/test_session.py
+++ b/tests/pipeline/test_session.py
@@ -2,6 +2,8 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
+from aind_behavior_vr_foraging_packaging._base import write_parquet
+
 
 def _make_mock_proc(name: str) -> MagicMock:
     df = pd.DataFrame({"x": [1]})
@@ -16,6 +18,9 @@ def _make_mock_proc(name: str) -> MagicMock:
     m = MagicMock()
     m.output_name = name
     m.compute.return_value = df
+    m.write_parquet.side_effect = lambda output_dir, filename=None: write_parquet(
+        m.compute(), output_dir / (filename or f"{name}.parquet")
+    )
     return m
 
 

--- a/tests/processing/test_session_metadata.py
+++ b/tests/processing/test_session_metadata.py
@@ -51,6 +51,35 @@ def _make_dataset(
     return ds
 
 
+def _make_dataset_with_schemas(
+    *,
+    session: dict | Session | None = None,
+    rig: dict | Session | None = None,
+    task_logic: dict | Session | None = None,
+    stream_path: str | None = _STREAM_PATH,
+) -> MagicMock:
+    """Return a mock dataset with distinct payloads for Session, Rig and TaskLogic.
+
+    Unlike :func:`_make_dataset`, each ``InputSchemas`` node gets its own payload,
+    so ``session``/``rig``/``task_logic`` can be asserted independently.
+    """
+    payloads = {
+        "Session": _VALID if session is None else session,
+        "Rig": rig,
+        "TaskLogic": task_logic,
+    }
+
+    def _at(name: str) -> MagicMock:
+        node = MagicMock()
+        node.reader_params.path = stream_path
+        node.load.return_value.data = payloads[name]
+        return node
+
+    ds = MagicMock()
+    ds.at.return_value.at.return_value.at.side_effect = _at
+    return ds
+
+
 # ---------------------------------------------------------------------------
 # session_id is the directory name, always
 # ---------------------------------------------------------------------------
@@ -158,6 +187,62 @@ def test_unloadable_stream_propagates(error):
     proc = SessionMetadataProcessor(_make_dataset(error=error))
     with pytest.raises(type(error)):
         proc._compute()
+
+
+# ---------------------------------------------------------------------------
+# session / rig / task_logic are carried verbatim, as JSON strings
+# ---------------------------------------------------------------------------
+
+
+def test_dict_payloads_are_carried_verbatim():
+    """Legacy (plain-``Json``) streams are already JSON-safe dicts; just carry them."""
+    rig = {"rig_name": "vr-foraging-1", "calibration": {"gain": 1.5}}
+    task_logic = {"task_parameters": {"n_patches": 4}}
+    ds = _make_dataset_with_schemas(rig=rig, task_logic=task_logic)
+
+    df = SessionMetadataProcessor(ds)._compute()
+
+    assert df["session"].iloc[0] == _VALID
+    assert df["rig"].iloc[0] == rig
+    assert df["task_logic"].iloc[0] == task_logic
+
+
+def test_pydantic_payloads_are_model_dumped():
+    """A BaseModel payload is normalized with model_dump(mode='json') first."""
+    rig = Session(subject="rig-subject", session_name="n/a")
+    task_logic = Session(subject="task-logic-subject", session_name="n/a")
+    ds = _make_dataset_with_schemas(rig=rig, task_logic=task_logic)
+
+    df = SessionMetadataProcessor(ds)._compute()
+
+    assert df["rig"].iloc[0] == rig.model_dump(mode="json")
+    assert df["task_logic"].iloc[0] == task_logic.model_dump(mode="json")
+
+
+def test_session_column_matches_the_metadata_fields():
+    """The `session` column is the same Session stream subject/date were read from."""
+    ds = _make_dataset_with_schemas(rig={"a": 1}, task_logic={"b": 2})
+
+    df = SessionMetadataProcessor(ds)._compute()
+
+    assert df["session"].iloc[0] == _VALID
+
+
+def test_write_parquet_tags_json_fields_with_the_json_logical_type(tmp_path):
+    """SessionMetadataProcessor overrides write_parquet to tag session/rig/task_logic."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    ds = _make_dataset_with_schemas(rig={"a": 1}, task_logic={"b": 2})
+    proc = SessionMetadataProcessor(ds)
+
+    proc.write_parquet(tmp_path)
+
+    table = pq.read_table(tmp_path / "session.parquet")
+    assert table.schema.field("session").type == pa.json_(pa.utf8())
+    assert table.schema.field("rig").type == pa.json_(pa.utf8())
+    assert table.schema.field("task_logic").type == pa.json_(pa.utf8())
+    assert table.schema.field("session_id").type not in (pa.json_(pa.utf8()), pa.json_(pa.large_utf8()))
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_abstract_processor.py
+++ b/tests/test_abstract_processor.py
@@ -56,6 +56,68 @@ def test_output_name_uses_class_override():
 
 
 # ---------------------------------------------------------------------------
+# write_parquet — default implementation, overridable per processor
+# ---------------------------------------------------------------------------
+
+
+def test_write_parquet_writes_a_readable_file(tmp_path):
+    import pyarrow.parquet as pq
+
+    proc = _Minimal.__new__(_Minimal)
+    proc._dataset = MagicMock()
+    proc._dataset.version = "0.6.0"
+
+    proc.write_parquet(tmp_path)
+
+    assert pq.read_table(tmp_path / "__minimal.parquet").to_pandas()["x"].tolist() == [1, 2, 3]
+
+
+def test_write_parquet_promotes_attrs_to_schema_metadata(tmp_path):
+    import pyarrow.parquet as pq
+
+    proc = _Minimal.__new__(_Minimal)
+    proc._dataset = MagicMock()
+    proc._dataset.version = "0.6.0"
+
+    proc.write_parquet(tmp_path)
+
+    assert pq.read_metadata(tmp_path / "__minimal.parquet").metadata[b"processor"] == b"_Minimal"
+
+
+def test_write_parquet_filename_overrides_the_processor_name(tmp_path):
+    import pyarrow.parquet as pq
+
+    proc = _Minimal.__new__(_Minimal)
+    proc._dataset = MagicMock()
+    proc._dataset.version = "0.6.0"
+
+    proc.write_parquet(tmp_path, filename="custom.parquet")
+
+    assert pq.read_table(tmp_path / "custom.parquet").to_pandas()["x"].tolist() == [1, 2, 3]
+
+
+def test_write_parquet_override_replaces_the_default(tmp_path):
+    """SessionMetadataProcessor is the real ``write_parquet`` override in the
+    codebase: it computes a genuine SessionMetadata and tags its ``Json[...]``
+    fields with Parquet's native JSON logical type instead of an opaque string."""
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+
+    from aind_behavior_vr_foraging_packaging.processing import SessionMetadataProcessor
+
+    ds = MagicMock()
+    stream = ds.at.return_value.at.return_value.at.return_value
+    stream.reader_params.path = "/data/behavior_815103_2025-11-05_22-52-21/behavior/Logs/session_input.json"
+    stream.load.return_value.data = {"subject": "815103", "date": "2025-11-05T22:52:21Z"}
+    ds.version = "1.0.0"
+
+    proc = SessionMetadataProcessor(ds)
+    proc.write_parquet(tmp_path)
+
+    assert pq.read_table(tmp_path / "session.parquet").schema.field("session").type == pa.json_(pa.utf8())
+
+
+# ---------------------------------------------------------------------------
 # session_root — shared by SessionMetadataProcessor and process_session
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #63.

## What changed

- `SessionMetadata` gained three `Json[Any]` fields (`session`, `rig`, `task_logic`) carrying the contraqctor `Behavior/InputSchemas/{Session,Rig,TaskLogic}` streams verbatim, so the full raw config is discoverable straight from `session.parquet` without a second pass over the dataset. Legacy (`< 1.0`) datasets read these as plain dicts; current datasets read `PydanticModel`s and `model_dump(mode="json")` them first.
- `AbstractProcessor` gained `write_parquet(output_dir, filename=None)`, a third concrete/overridable method alongside `compute()` and `nwbize()`. Its default calls `compute()` internally (independent of the caller, like `nwbize()` already was) and writes `output_dir/{output_name}.parquet`.
- `SessionMetadataProcessor` overrides `write_parquet` to tag its `Json[...]` fields with Parquet's native `JSON` logical type (`pa.json_()`), not just an opaque string column, verified by reading the written file back with `pq.ParquetFile(...).schema`.
- `cached_frame` now decorates all seven processors' `_compute` (previously five): `write_parquet()` re-entering `compute()` on every default run made `SessionMetadataProcessor` and `SoftwareEventsProcessor` need it too.

## Notes

- Aggregated (Phase 2) `session.parquet` writes `session`/`rig`/`task_logic` as plain strings, not JSON-tagged, since aggregation has no live per-session processor instance to dispatch `write_parquet` through.

## Testing

- `tests/processing/test_session_metadata.py`, `tests/test_abstract_processor.py`,
  `tests/pipeline/test_session.py`, `tests/pipeline/test_batch.py` updated/added.